### PR TITLE
Implement run_transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ futures-util = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 async-trait = "0.1"
 hex = "0.4"
+backoff = { version = "0.4.0", features = ["tokio"] }
 
 [dev-dependencies]
 cargo-husky = { version = "1.5", default-features = false, features = ["run-for-all", "prepush-hook", "run-cargo-fmt"] }

--- a/examples/read-write-transactions.rs
+++ b/examples/read-write-transactions.rs
@@ -1,0 +1,199 @@
+use std::pin::Pin;
+
+use backoff::{future::retry, ExponentialBackoff};
+use firestore::{
+    errors::{FirestoreDatabaseError, FirestoreError},
+    *,
+};
+use futures::stream::FuturesOrdered;
+use serde::{Deserialize, Serialize};
+use tokio_stream::StreamExt;
+
+pub fn config_env_var(name: &str) -> Result<String, String> {
+    std::env::var(name).map_err(|e| format!("{}: {}", name, e))
+}
+
+// Example structure to play with
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct MyTestStructure {
+    counter: i64,
+}
+
+const TEST_COLLECTION_NAME: &'static str = "test";
+const TEST_DOCUMENT_ID: &str = "test_doc_id";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Logging with debug enabled
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter("firestore=debug")
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    // Create an instance
+    let db = FirestoreDb::new(&config_env_var("PROJECT_ID")?).await?;
+
+    const COUNT_ITERATIONS: i64 = 50;
+
+    println!("Creating initial document...");
+
+    // Remove if it already exists
+    db.fluent()
+        .delete()
+        .from(TEST_COLLECTION_NAME)
+        .document_id(TEST_DOCUMENT_ID)
+        .execute()
+        .await?;
+
+    // Let's insert some data
+    let my_struct = MyTestStructure { counter: 0 };
+
+    db.fluent()
+        .insert()
+        .into(TEST_COLLECTION_NAME)
+        .document_id(TEST_DOCUMENT_ID)
+        .object(&my_struct)
+        .execute()
+        .await?;
+
+    println!("Running transactions...");
+
+    let mut futures = FuturesOrdered::new();
+
+    for _ in 0..COUNT_ITERATIONS {
+        futures.push_back(increment_counter(&db));
+    }
+
+    let results = futures.collect::<Vec<_>>().await;
+    dbg!(results);
+
+    println!("Testing results...");
+
+    let test_structure: MyTestStructure = db
+        .fluent()
+        .select()
+        .by_id_in(TEST_COLLECTION_NAME)
+        .obj()
+        .one(TEST_DOCUMENT_ID)
+        .await?
+        .expect("Missing document");
+
+    assert_eq!(test_structure.counter, COUNT_ITERATIONS);
+
+    Ok(())
+}
+
+async fn increment_counter(db: &FirestoreDb) -> Result<(), FirestoreError> {
+    run_transaction(&db, |db, transaction| {
+        Box::pin(async move {
+            let mut test_structure: MyTestStructure = db
+                .fluent()
+                .select()
+                .by_id_in(TEST_COLLECTION_NAME)
+                .obj()
+                // .one_with_transaction(TEST_DOCUMENT_ID, &mut transaction)
+                .one(TEST_DOCUMENT_ID)
+                .await?
+                .expect("Missing document");
+
+            test_structure.counter += 1;
+
+            db.fluent()
+                .update()
+                .fields(paths!(MyTestStructure::{
+                    counter
+                }))
+                .in_col(TEST_COLLECTION_NAME)
+                .document_id(TEST_DOCUMENT_ID)
+                .object(&test_structure)
+                .add_to_transaction(transaction)?;
+
+            Ok(())
+        })
+    })
+    .await?;
+
+    Ok(())
+}
+
+async fn run_transaction<T, F>(db: &FirestoreDb, func: F) -> Result<T, FirestoreError>
+where
+    F: for<'a> Fn(
+        FirestoreDb,
+        &'a mut FirestoreTransaction,
+    ) -> Pin<Box<dyn futures::Future<Output = Result<T, FirestoreError>> + 'a>>,
+{
+    // Perform our initial attempt. If this fails and the backend tells us we can retry,
+    // we'll try again with exponential backoff using the first attempt's transaction ID.
+    let transaction_id = {
+        let mut transaction = db.begin_transaction().await?;
+
+        let cdb = db.clone_with_consistency_selector(FirestoreConsistencySelector::Transaction(
+            transaction.transaction_id.clone(),
+        ));
+
+        let ret_val = func(cdb, &mut transaction).await?;
+
+        let transaction_id = transaction.transaction_id.clone();
+
+        match transaction.commit().await {
+            Ok(_) => return Ok(ret_val),
+            Err(e) => match e {
+                FirestoreError::DatabaseError(FirestoreDatabaseError {
+                    retry_possible: true,
+                    ..
+                }) => {
+                    // Ignore; we'll try again
+                }
+                FirestoreError::DatabaseError(FirestoreDatabaseError {
+                    retry_possible: false,
+                    ..
+                }) => {
+                    return Err(e);
+                }
+                e => return Err(e),
+            },
+        }
+
+        transaction_id
+    };
+
+    // We failed the first time. Now we must change the transaction mode to signal that we're retrying with the original transaction ID.
+    let result = retry(ExponentialBackoff::default(), || async {
+        let options = FirestoreTransactionOptions {
+            mode: FirestoreTransactionMode::ReadWriteRetry(transaction_id.clone()),
+        };
+        let mut transaction = db.begin_transaction_with_options(options).await?;
+
+        let cdb = db.clone_with_consistency_selector(FirestoreConsistencySelector::Transaction(
+            transaction.transaction_id.clone(),
+        ));
+
+        let ret_val = func(cdb, &mut transaction).await?;
+
+        match transaction.commit().await {
+            Ok(_) => return Ok(ret_val),
+            Err(e) => match e {
+                FirestoreError::DatabaseError(FirestoreDatabaseError {
+                    retry_possible: true,
+                    ..
+                }) => {
+                    eprintln!("Got back retryable error: {e}");
+                    return Err(backoff::Error::transient(e));
+                }
+                FirestoreError::DatabaseError(FirestoreDatabaseError {
+                    retry_possible: false,
+                    ..
+                }) => {
+                    return Err(backoff::Error::permanent(e));
+                }
+                e => return Err(backoff::Error::permanent(e)),
+            },
+        }
+    })
+    .await;
+
+    // TODO If the final result was Err, do we still need to call `rollback`?
+
+    result
+}

--- a/examples/read-write-transactions.rs
+++ b/examples/read-write-transactions.rs
@@ -16,6 +16,8 @@ struct MyTestStructure {
 const TEST_COLLECTION_NAME: &'static str = "test";
 const TEST_DOCUMENT_ID: &str = "test_doc_id";
 
+/// Creates a document with a counter set to 0 and then concurrently executes futures for `COUNT_ITERATIONS` iterations.
+/// Finally, it reads the document again and verifies that the counter matches the expected number of iterations.
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Logging with debug enabled
@@ -85,7 +87,6 @@ async fn increment_counter(db: &FirestoreDb) -> Result<(), FirestoreError> {
                 .select()
                 .by_id_in(TEST_COLLECTION_NAME)
                 .obj()
-                // .one_with_transaction(TEST_DOCUMENT_ID, &mut transaction)
                 .one(TEST_DOCUMENT_ID)
                 .await?
                 .expect("Missing document");

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 mod get;
+use backoff::{future::retry, ExponentialBackoff};
 pub use get::*;
 
 mod create;
@@ -63,9 +64,10 @@ mod batch_simple_writer;
 pub use batch_simple_writer::*;
 
 use crate::errors::{
-    FirestoreError, FirestoreInvalidParametersError, FirestoreInvalidParametersPublicDetails,
+    FirestoreDatabaseError, FirestoreError, FirestoreInvalidParametersError,
+    FirestoreInvalidParametersPublicDetails,
 };
-use std::fmt::Formatter;
+use std::{fmt::Formatter, pin::Pin};
 
 #[derive(Clone)]
 pub struct FirestoreDb {
@@ -159,6 +161,89 @@ impl FirestoreDb {
             .await
             .ok();
         Ok(())
+    }
+
+    pub async fn run_transaction<T, F>(&self, func: F) -> Result<T, FirestoreError>
+    where
+        F: for<'a> Fn(
+            FirestoreDb,
+            &'a mut FirestoreTransaction,
+        )
+            -> Pin<Box<dyn futures::Future<Output = Result<T, FirestoreError>> + 'a>>,
+    {
+        // Perform our initial attempt. If this fails and the backend tells us we can retry,
+        // we'll try again with exponential backoff using the first attempt's transaction ID.
+        let transaction_id = {
+            let mut transaction = self.begin_transaction().await?;
+
+            let cdb = self.clone_with_consistency_selector(
+                FirestoreConsistencySelector::Transaction(transaction.transaction_id.clone()),
+            );
+
+            let ret_val = func(cdb, &mut transaction).await?;
+
+            let transaction_id = transaction.transaction_id.clone();
+
+            match transaction.commit().await {
+                Ok(_) => return Ok(ret_val),
+                Err(e) => match e {
+                    FirestoreError::DatabaseError(FirestoreDatabaseError {
+                        retry_possible: true,
+                        ..
+                    }) => {
+                        // Ignore; we'll try again
+                    }
+                    FirestoreError::DatabaseError(FirestoreDatabaseError {
+                        retry_possible: false,
+                        ..
+                    }) => {
+                        return Err(e);
+                    }
+                    e => return Err(e),
+                },
+            }
+
+            transaction_id
+        };
+
+        // We failed the first time. Now we must change the transaction mode to signal that we're retrying with the original transaction ID.
+        let result = retry(ExponentialBackoff::default(), || async {
+            let options = FirestoreTransactionOptions {
+                mode: FirestoreTransactionMode::ReadWriteRetry(transaction_id.clone()),
+            };
+            let mut transaction = self.begin_transaction_with_options(options).await?;
+
+            let cdb = self.clone_with_consistency_selector(
+                FirestoreConsistencySelector::Transaction(transaction.transaction_id.clone()),
+            );
+
+            let ret_val = func(cdb, &mut transaction).await?;
+
+            match transaction.commit().await {
+                Ok(_) => return Ok(ret_val),
+                Err(e) => match e {
+                    FirestoreError::DatabaseError(FirestoreDatabaseError {
+                        retry_possible: true,
+                        ..
+                    }) => {
+                        eprintln!("Got back retryable error: {e}");
+                        return Err(backoff::Error::transient(e));
+                    }
+                    FirestoreError::DatabaseError(FirestoreDatabaseError {
+                        retry_possible: false,
+                        ..
+                    }) => {
+                        return Err(backoff::Error::permanent(e));
+                    }
+                    e => return Err(backoff::Error::permanent(e)),
+                },
+            }
+        })
+        .await;
+
+        // TODO If the final result was Err, do we still need to call `rollback`?
+
+        result
     }
 
     #[inline]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
 mod get;
-use backoff::{future::retry, ExponentialBackoff};
 pub use get::*;
 
 mod create;
@@ -64,10 +63,9 @@ mod batch_simple_writer;
 pub use batch_simple_writer::*;
 
 use crate::errors::{
-    FirestoreDatabaseError, FirestoreError, FirestoreInvalidParametersError,
-    FirestoreInvalidParametersPublicDetails,
+    FirestoreError, FirestoreInvalidParametersError, FirestoreInvalidParametersPublicDetails,
 };
-use std::{fmt::Formatter, pin::Pin};
+use std::fmt::Formatter;
 
 #[derive(Clone)]
 pub struct FirestoreDb {
@@ -161,89 +159,6 @@ impl FirestoreDb {
             .await
             .ok();
         Ok(())
-    }
-
-    pub async fn run_transaction<T, F>(&self, func: F) -> Result<T, FirestoreError>
-    where
-        F: for<'a> Fn(
-            FirestoreDb,
-            &'a mut FirestoreTransaction,
-        )
-            -> Pin<Box<dyn futures::Future<Output = Result<T, FirestoreError>> + 'a>>,
-    {
-        // Perform our initial attempt. If this fails and the backend tells us we can retry,
-        // we'll try again with exponential backoff using the first attempt's transaction ID.
-        let transaction_id = {
-            let mut transaction = self.begin_transaction().await?;
-
-            let cdb = self.clone_with_consistency_selector(
-                FirestoreConsistencySelector::Transaction(transaction.transaction_id.clone()),
-            );
-
-            let ret_val = func(cdb, &mut transaction).await?;
-
-            let transaction_id = transaction.transaction_id.clone();
-
-            match transaction.commit().await {
-                Ok(_) => return Ok(ret_val),
-                Err(e) => match e {
-                    FirestoreError::DatabaseError(FirestoreDatabaseError {
-                        retry_possible: true,
-                        ..
-                    }) => {
-                        // Ignore; we'll try again
-                    }
-                    FirestoreError::DatabaseError(FirestoreDatabaseError {
-                        retry_possible: false,
-                        ..
-                    }) => {
-                        return Err(e);
-                    }
-                    e => return Err(e),
-                },
-            }
-
-            transaction_id
-        };
-
-        // We failed the first time. Now we must change the transaction mode to signal that we're retrying with the original transaction ID.
-        let result = retry(ExponentialBackoff::default(), || async {
-            let options = FirestoreTransactionOptions {
-                mode: FirestoreTransactionMode::ReadWriteRetry(transaction_id.clone()),
-            };
-            let mut transaction = self.begin_transaction_with_options(options).await?;
-
-            let cdb = self.clone_with_consistency_selector(
-                FirestoreConsistencySelector::Transaction(transaction.transaction_id.clone()),
-            );
-
-            let ret_val = func(cdb, &mut transaction).await?;
-
-            match transaction.commit().await {
-                Ok(_) => return Ok(ret_val),
-                Err(e) => match e {
-                    FirestoreError::DatabaseError(FirestoreDatabaseError {
-                        retry_possible: true,
-                        ..
-                    }) => {
-                        eprintln!("Got back retryable error: {e}");
-                        return Err(backoff::Error::transient(e));
-                    }
-                    FirestoreError::DatabaseError(FirestoreDatabaseError {
-                        retry_possible: false,
-                        ..
-                    }) => {
-                        return Err(backoff::Error::permanent(e));
-                    }
-                    e => return Err(backoff::Error::permanent(e)),
-                },
-            }
-        })
-        .await;
-
-        // TODO If the final result was Err, do we still need to call `rollback`?
-
-        result
     }
 
     #[inline]

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -3,8 +3,8 @@ use std::pin::Pin;
 use crate::errors::FirestoreDatabaseError;
 use crate::timestamp_utils::from_timestamp;
 use crate::{FirestoreConsistencySelector, FirestoreDb, FirestoreError, FirestoreResult};
-use backoff::ExponentialBackoff;
 use backoff::future::retry;
+use backoff::ExponentialBackoff;
 use gcloud_sdk::google::firestore::v1::{BeginTransactionRequest, CommitRequest, RollbackRequest};
 use rsb_derive::Builder;
 use tracing::*;
@@ -13,6 +13,14 @@ use tracing::*;
 pub struct FirestoreTransactionOptions {
     #[default = "FirestoreTransactionMode::ReadWrite"]
     pub mode: FirestoreTransactionMode,
+}
+
+impl Default for FirestoreTransactionOptions {
+    fn default() -> Self {
+        Self {
+            mode: FirestoreTransactionMode::ReadWrite,
+        }
+    }
 }
 
 impl TryFrom<FirestoreTransactionOptions>
@@ -216,10 +224,26 @@ impl FirestoreDb {
         )
             -> Pin<Box<dyn futures::Future<Output = Result<T, FirestoreError>> + 'a>>,
     {
+        let options = FirestoreTransactionOptions::default();
+        self.run_transaction_with_options(func, options).await
+    }
+
+    pub async fn run_transaction_with_options<T, F>(
+        &self,
+        func: F,
+        options: FirestoreTransactionOptions,
+    ) -> Result<T, FirestoreError>
+    where
+        F: for<'a> Fn(
+            FirestoreDb,
+            &'a mut FirestoreTransaction,
+        )
+            -> Pin<Box<dyn futures::Future<Output = Result<T, FirestoreError>> + 'a>>,
+    {
         // Perform our initial attempt. If this fails and the backend tells us we can retry,
         // we'll try again with exponential backoff using the first attempt's transaction ID.
         let transaction_id = {
-            let mut transaction = self.begin_transaction().await?;
+            let mut transaction = self.begin_transaction_with_options(options).await?;
 
             let cdb = self.clone_with_consistency_selector(
                 FirestoreConsistencySelector::Transaction(transaction.transaction_id.clone()),
@@ -236,7 +260,7 @@ impl FirestoreDb {
                         retry_possible: true,
                         ..
                     }) => {
-                        // Ignore; we'll try again
+                        // Ignore; we'll try again below
                     }
                     FirestoreError::DatabaseError(FirestoreDatabaseError {
                         retry_possible: false,
@@ -252,7 +276,7 @@ impl FirestoreDb {
         };
 
         // We failed the first time. Now we must change the transaction mode to signal that we're retrying with the original transaction ID.
-        let result = retry(ExponentialBackoff::default(), || async {
+        retry(ExponentialBackoff::default(), || async {
             let options = FirestoreTransactionOptions {
                 mode: FirestoreTransactionMode::ReadWriteRetry(transaction_id.clone()),
             };
@@ -265,30 +289,25 @@ impl FirestoreDb {
             let ret_val = func(cdb, &mut transaction).await?;
 
             match transaction.commit().await {
-                Ok(_) => return Ok(ret_val),
+                Ok(_) => Ok(ret_val),
                 Err(e) => match e {
                     FirestoreError::DatabaseError(FirestoreDatabaseError {
                         retry_possible: true,
                         ..
                     }) => {
                         eprintln!("Got back retryable error: {e}");
-                        return Err(backoff::Error::transient(e));
+                        Err(backoff::Error::transient(e))
                     }
                     FirestoreError::DatabaseError(FirestoreDatabaseError {
                         retry_possible: false,
                         ..
-                    }) => {
-                        return Err(backoff::Error::permanent(e));
-                    }
-                    e => return Err(backoff::Error::permanent(e)),
+                    }) => Err(backoff::Error::permanent(e)),
+                    e => Err(backoff::Error::permanent(e)),
                 },
             }
         })
-        .await;
+        .await
 
         // TODO If the final result was Err, do we still need to call `rollback`?
-
-        result
     }
-
 }

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -1,5 +1,10 @@
+use std::pin::Pin;
+
+use crate::errors::FirestoreDatabaseError;
 use crate::timestamp_utils::from_timestamp;
 use crate::{FirestoreConsistencySelector, FirestoreDb, FirestoreError, FirestoreResult};
+use backoff::ExponentialBackoff;
+use backoff::future::retry;
 use gcloud_sdk::google::firestore::v1::{BeginTransactionRequest, CommitRequest, RollbackRequest};
 use rsb_derive::Builder;
 use tracing::*;
@@ -202,4 +207,88 @@ impl FirestoreDb {
     ) -> FirestoreResult<FirestoreTransaction> {
         FirestoreTransaction::new(self, options).await
     }
+
+    pub async fn run_transaction<T, F>(&self, func: F) -> Result<T, FirestoreError>
+    where
+        F: for<'a> Fn(
+            FirestoreDb,
+            &'a mut FirestoreTransaction,
+        )
+            -> Pin<Box<dyn futures::Future<Output = Result<T, FirestoreError>> + 'a>>,
+    {
+        // Perform our initial attempt. If this fails and the backend tells us we can retry,
+        // we'll try again with exponential backoff using the first attempt's transaction ID.
+        let transaction_id = {
+            let mut transaction = self.begin_transaction().await?;
+
+            let cdb = self.clone_with_consistency_selector(
+                FirestoreConsistencySelector::Transaction(transaction.transaction_id.clone()),
+            );
+
+            let ret_val = func(cdb, &mut transaction).await?;
+
+            let transaction_id = transaction.transaction_id.clone();
+
+            match transaction.commit().await {
+                Ok(_) => return Ok(ret_val),
+                Err(e) => match e {
+                    FirestoreError::DatabaseError(FirestoreDatabaseError {
+                        retry_possible: true,
+                        ..
+                    }) => {
+                        // Ignore; we'll try again
+                    }
+                    FirestoreError::DatabaseError(FirestoreDatabaseError {
+                        retry_possible: false,
+                        ..
+                    }) => {
+                        return Err(e);
+                    }
+                    e => return Err(e),
+                },
+            }
+
+            transaction_id
+        };
+
+        // We failed the first time. Now we must change the transaction mode to signal that we're retrying with the original transaction ID.
+        let result = retry(ExponentialBackoff::default(), || async {
+            let options = FirestoreTransactionOptions {
+                mode: FirestoreTransactionMode::ReadWriteRetry(transaction_id.clone()),
+            };
+            let mut transaction = self.begin_transaction_with_options(options).await?;
+
+            let cdb = self.clone_with_consistency_selector(
+                FirestoreConsistencySelector::Transaction(transaction.transaction_id.clone()),
+            );
+
+            let ret_val = func(cdb, &mut transaction).await?;
+
+            match transaction.commit().await {
+                Ok(_) => return Ok(ret_val),
+                Err(e) => match e {
+                    FirestoreError::DatabaseError(FirestoreDatabaseError {
+                        retry_possible: true,
+                        ..
+                    }) => {
+                        eprintln!("Got back retryable error: {e}");
+                        return Err(backoff::Error::transient(e));
+                    }
+                    FirestoreError::DatabaseError(FirestoreDatabaseError {
+                        retry_possible: false,
+                        ..
+                    }) => {
+                        return Err(backoff::Error::permanent(e));
+                    }
+                    e => return Err(backoff::Error::permanent(e)),
+                },
+            }
+        })
+        .await;
+
+        // TODO If the final result was Err, do we still need to call `rollback`?
+
+        result
+    }
+
 }


### PR DESCRIPTION
# Intent

This PR aims to implement a feature found in Firestore implementations for other languages, such as [Go](https://github.com/googleapis/google-cloud-go/blob/feb6b0a8b771875a55c75fa959e19f6f12079030/firestore/transaction.go#LL93C41-L93C41) and [Typescript](https://github.com/googleapis/nodejs-firestore/blob/d6d44e1e58b379f33f893fa6b151abfe1352b9b3/dev/src/transaction.ts#LL470C9-L470C23).

These "run transaction" functions allow the user to pass in a closure that performs reads and/or writes and attempts to commit a transaction with a limited number of retries. Many of the details are not exposed to the user.

I've introduced an example that uses `run_transaction` to increment a counter concurrently using `FuturesOrdered`.

# Potential Problems
- ~I've introduced the [backoff](https://crates.io/crates/backoff) crate into the Cargo.toml. If this is not desirable, we can rework the retry mechanism such that it does not bring in a dependency.~
- Users' closures must be wrapped in `Box::pin` presently. Is it possible to push this into the `run_transaction` function itself?
- ~I've placed the implementation directly into `FirestoreDb`. This seems okay, but is it the correct place for it?~
- `run_transaction` will always use `ReadWrite` for the consistency selector. Shouldn't we handle `ReadOnly` transactions as well?
- We should expose some options about the transaction behavior to the user, as the SDKs in other languages do. This includes retry configuration, a manual specification of the transaction read time, and whether or not the transaction should be read-only (which perhaps solves the previous potential issue)
- ~All reads must take place before any writes in the transaction, but I haven't tested to verify that we gracefully handle that error.~