### PR TITLE
Re-export ValueStruct import

### DIFF
--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use chrono::prelude::*;
 use firestore::*;
-use rvstruct::ValueStruct;
 use serde::{Deserialize, Serialize};
 use std::io::Read;
 

--- a/src/db/listen_changes.rs
+++ b/src/db/listen_changes.rs
@@ -10,7 +10,7 @@ use futures::TryFutureExt;
 use futures::TryStreamExt;
 use gcloud_sdk::google::firestore::v1::*;
 use rsb_derive::*;
-use rvstruct::ValueStruct;
+pub use rvstruct::ValueStruct;
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
This will allow using `ValueStruct` from this crate instead of installing `rvstruct` as a separate dependency.