### PR TITLE
Re-export async_trait

### DIFF
--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -114,8 +114,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .start(|event| async move {
             match event {
                 FirestoreListenEvent::DocumentChange(ref doc_change) => {
+                    println!("{doc_change:?}");
+
                     if let Some(doc) = &doc_change.document {
-                        println!("{doc_change:?}");
                         let obj: MyTestStructure =
                             FirestoreDb::deserialize_doc_to::<MyTestStructure>(doc)
                                 .expect("Deserialized object");

--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -115,14 +115,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             match event {
                 FirestoreListenEvent::DocumentChange(ref doc_change) => {
                     if let Some(doc) = &doc_change.document {
+                        println!("{doc_change:?}");
                         let obj: MyTestStructure =
                             FirestoreDb::deserialize_doc_to::<MyTestStructure>(doc)
                                 .expect("Deserialized object");
-                        println!("As object: {:?}", obj);
+                        println!("As object: {obj:?}");
                     }
                 }
                 _ => {
-                    println!("Received a listen response event to handle");
+                    println!("Received a listen response event to handle: {event:?}");
                 }
             }
 

--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .start(|event| async move {
             match event {
                 FirestoreListenEvent::DocumentChange(ref doc_change) => {
-                    println!("{doc_change:?}");
+                    println!("Doc changed: {doc_change:?}");
 
                     if let Some(doc) = &doc_change.document {
                         let obj: MyTestStructure =

--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -43,10 +43,10 @@ impl FirestoreResumeStateStorage for TempFileTokenStorage {
         let token = std::fs::read_to_string(target_state_file_name)
             .ok()
             .map(|str| {
-                hex::decode(&str)
+                hex::decode(str)
                     .map(FirestoreListenerToken::new)
                     .map(FirestoreListenerTargetResumeType::Token)
-                    .map_err(|e| Box::new(e))
+                    .map_err(Box::new)
             })
             .transpose()?;
 
@@ -114,8 +114,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .start(|event| async move {
             match event {
                 FirestoreListenEvent::DocumentChange(ref doc_change) => {
-                    println!("Doc changed: {:?}", doc_change);
-
                     if let Some(doc) = &doc_change.document {
                         let obj: MyTestStructure =
                             FirestoreDb::deserialize_doc_to::<MyTestStructure>(doc)
@@ -124,7 +122,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     }
                 }
                 _ => {
-                    println!("Received a listen response event to handle: {:?}", event);
+                    println!("Received a listen response event to handle");
                 }
             }
 

--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use chrono::prelude::*;
 use firestore::*;
 use serde::{Deserialize, Serialize};

--- a/src/db/listen_changes.rs
+++ b/src/db/listen_changes.rs
@@ -2,7 +2,7 @@ use crate::db::safe_document_path;
 use crate::errors::*;
 use crate::timestamp_utils::to_timestamp;
 use crate::{FirestoreDb, FirestoreQueryParams, FirestoreResult};
-use async_trait::async_trait;
+pub use async_trait::async_trait;
 use chrono::prelude::*;
 use futures::stream::BoxStream;
 use futures::StreamExt;


### PR DESCRIPTION
Same rationale as #67. Also see [axum](https://docs.rs/axum/latest/axum/#reexports) re-exporting async_trait.

This also fixes the [listen-changes.rs](https://github.com/abdolence/firestore-rs/pull/69/commits/fd2e8ab3a625cb50710cd67820e375589ec492bd) example. Previously, it wouldn't compile due to attempting to print some structs that didn't implement Debug, and also had some linting errors flagged by clippy.