### PR TITLE
Default for custom serialized types 

### DIFF
--- a/src/firestore_serde/latlng_serializers.rs
+++ b/src/firestore_serde/latlng_serializers.rs
@@ -8,13 +8,13 @@ use crate::FirestoreValue;
 
 pub(crate) const FIRESTORE_LATLNG_TYPE_TAG_TYPE: &str = "FirestoreLatLng";
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, PartialOrd, Default)]
 pub struct FirestoreGeoPoint {
     pub latitude: f64,
     pub longitude: f64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, PartialOrd, Default)]
 pub struct FirestoreLatLng(pub FirestoreGeoPoint);
 
 pub fn serialize_latlng_for_firestore<T: ?Sized + Serialize>(

--- a/src/firestore_serde/reference_serializers.rs
+++ b/src/firestore_serde/reference_serializers.rs
@@ -6,7 +6,7 @@ use crate::FirestoreValue;
 
 pub(crate) const FIRESTORE_REFERENCE_TYPE_TAG_TYPE: &str = "FirestoreReference";
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Default)]
 pub struct FirestoreReference(pub String);
 
 pub mod serialize_as_reference {

--- a/src/firestore_serde/timestamp_serializers.rs
+++ b/src/firestore_serde/timestamp_serializers.rs
@@ -7,7 +7,7 @@ use crate::{
     FirestoreValue,
 };
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Default)]
 pub struct FirestoreTimestamp(pub DateTime<Utc>);
 
 impl From<DateTime<Utc>> for FirestoreTimestamp {


### PR DESCRIPTION
deriving the `Default` trait for these types can help when users try to derive `Default` for thier own types. This is especially useful when updating only certain fields of a document.

Example:
```rust
self.db
    .fluent()
    .update()
    .fields(paths!(MyStruct::{my_field}))
    .in_col("myCollection")
    .document_id("myDocument")
    .object(&MyStruct{
        my_field: "some_value",
        ..Default::default()
    })
    .execute::<MyStruct>()
    .await?;
```