### PR TITLE
fix deserialization when u64 is greater than i64::max

### DIFF
--- a/src/firestore_serde/deserializer.rs
+++ b/src/firestore_serde/deserializer.rs
@@ -441,11 +441,9 @@ impl<'de> serde::Deserializer<'de> for FirestoreValue {
         V: Visitor<'de>,
     {
         match self.value.value_type {
-            Some(value::ValueType::IntegerValue(v)) => {
-                visitor.visit_u64(v as u64)
-            },
+            Some(value::ValueType::IntegerValue(v)) => visitor.visit_u64(v as u64),
 
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 

--- a/src/firestore_serde/deserializer.rs
+++ b/src/firestore_serde/deserializer.rs
@@ -440,7 +440,13 @@ impl<'de> serde::Deserializer<'de> for FirestoreValue {
     where
         V: Visitor<'de>,
     {
-        self.deserialize_any(visitor)
+        match self.value.value_type {
+            Some(value::ValueType::IntegerValue(v)) => {
+                visitor.visit_u64(v as u64)
+            },
+
+            _ => unreachable!()
+        }
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>


### PR DESCRIPTION
I've been using the crate (amazing work by the way!) to deal with blockchain transactions and I've noticed that the deserialization for u64 that  are bigger than i64::MAX results in an error since it resorts to the deserialize_any method which always returns an i64 (which can't be cast to u64 when the written u64 > i64::MAX).

This pr just handles u64 deserialization without relying on `deserialize_any` by casting the truncated i64 to u64.