### PR TITLE
Fix to use $crate in path macros

### DIFF
--- a/src/struct_path_macro.rs
+++ b/src/struct_path_macro.rs
@@ -1,27 +1,27 @@
 #[macro_export]
 macro_rules! path {
     ($($x:tt)*) => {{
-        struct_path::path!($($x)*).to_string()
+        $crate::struct_path::path!($($x)*).to_string()
     }};
 }
 
 #[macro_export]
 macro_rules! paths {
     ($($x:tt)*) => {{
-        struct_path::paths!($($x)*).iter().map(|s| s.to_string()).collect::<Vec<String>>()
+        $crate::struct_path::paths!($($x)*).iter().map(|s| s.to_string()).collect::<Vec<String>>()
     }};
 }
 
 #[macro_export]
 macro_rules! path_camel_case {
     ($($x:tt)*) => {{
-        struct_path::path!($($x)*;case="camel").to_string()
+        $crate::struct_path::path!($($x)*;case="camel").to_string()
     }};
 }
 
 #[macro_export]
 macro_rules! paths_camel_case {
     ($($x:tt)*) => {{
-        struct_path::paths!($($x)*;case="camel").into_iter().map(|s| s.to_string()).collect::<Vec<String>>()
+        $crate::struct_path::paths!($($x)*;case="camel").into_iter().map(|s| s.to_string()).collect::<Vec<String>>()
     }}
 }

--- a/tests/macro_path_test.rs
+++ b/tests/macro_path_test.rs
@@ -1,0 +1,50 @@
+#[test]
+fn test_ambiguous_path_macro() {
+    struct MyTestStructure {
+        some_id: String,
+        some_num: u64,
+    }
+    assert_eq!(firestore::path!(MyTestStructure::some_id), "some_id");
+    assert_eq!(
+        firestore::paths!(MyTestStructure::{some_id, some_num}),
+        vec!["some_id".to_string(), "some_num".to_string()]
+    );
+    assert_eq!(
+        firestore::path_camel_case!(MyTestStructure::some_id),
+        "someId"
+    );
+    assert_eq!(
+        firestore::paths_camel_case!(MyTestStructure::{some_id, some_num}),
+        vec!["someId".to_string(), "someNum".to_string()]
+    );
+}
+
+mod struct_path {
+    #[macro_export]
+    macro_rules! path {
+        () => {
+            unreachable!()
+        };
+    }
+
+    #[macro_export]
+    macro_rules! paths {
+        ($($x:tt)*) => {{
+            unreachable!()
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! path_camel_case {
+        ($($x:tt)*) => {{
+            unreachable!()
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! paths_camel_case {
+        ($($x:tt)*) => {{
+            unreachable!()
+        }};
+    }
+}


### PR DESCRIPTION
```text
error[E0433]: failed to resolve: could not find `path` in `struct_path`
 --> tests/path_test.rs:7:16
  |
7 |     assert_eq!(firestore::path!(MyTestStructure::some_id), "some_id");
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `path` in `struct_path`
  |
  = note: this error originates in the macro `firestore::path` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `paths` in `struct_path`
 --> tests/path_test.rs:9:9
  |
9 |         firestore::paths!(MyTestStructure::{some_id, some_num}),
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `paths` in `struct_path`
  |
  = note: this error originates in the macro `firestore::paths` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `path` in `struct_path`
  --> tests/path_test.rs:13:9
   |
13 |         firestore::path_camel_case!(MyTestStructure::some_id),
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `path` in `struct_path`
   |
   = note: this error originates in the macro `firestore::path_camel_case` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `paths` in `struct_path`
  --> tests/path_test.rs:17:9
   |
17 |         firestore::paths_camel_case!(MyTestStructure::{some_id, some_num}),
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `paths` in `struct_path`
   |
   = note: this error originates in the macro `firestore::paths_camel_case` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0433`.
error: could not compile `firestore` (test "path_test") due to 4 previous errors

 *  The terminal process "cargo 'test', '--package', 'firestore', '--test', 'path_test', '--', 'test_ambiguous_path_macro', '--exact', '--nocapture'" terminated with exit code: 101.
 *  Terminal will be reused by tasks, press any key to close it.
```

FYI: <https://doc.rust-lang.org/reference/macros-by-example.html#metavariables>
