### PR TITLE
Use tracing fields to store variable log data

### DIFF
--- a/src/cache/backends/persistent_backend.rs
+++ b/src/cache/backends/persistent_backend.rs
@@ -26,13 +26,13 @@ impl FirestorePersistentCacheBackend {
 
         if !db_dir.exists() {
             debug!(
-                directory = %db_dir,
+                directory = %db_dir.display(),
                 "Creating a temp directory to store persistent cache.",
             );
             std::fs::create_dir_all(&db_dir)?;
         } else {
             debug!(
-                directory = %db_dir,
+                directory = %db_dir.display(),
                 "Using a temp directory to store persistent cache.",
             );
         }
@@ -120,7 +120,7 @@ impl FirestorePersistentCacheBackend {
                         .ready_chunks(100)
                         .for_each(|docs| async move {
                             if let Err(err) = self.write_batch_docs(collection_path, docs) {
-                                error!(err, "Error while preloading collection.");
+                                error!(?err, "Error while preloading collection.");
                             }
                         })
                         .await;
@@ -144,10 +144,7 @@ impl FirestorePersistentCacheBackend {
                 }
                 FirestoreCacheCollectionLoadMode::PreloadNone => {
                     let tx = self.redb.begin_write()?;
-                    debug!(
-                        collection_path
-                        "Creating corresponding collection table.",
-                    );
+                    debug!(collection_path, "Creating corresponding collection table.",);
                     tx.open_table(td)?;
                     tx.commit()?;
                 }

--- a/src/cache/backends/persistent_backend.rs
+++ b/src/cache/backends/persistent_backend.rs
@@ -26,14 +26,14 @@ impl FirestorePersistentCacheBackend {
 
         if !db_dir.exists() {
             debug!(
-                "Creating a temp directory to store persistent cache: {}",
-                db_dir.display()
+                directory = %db_dir,
+                "Creating a temp directory to store persistent cache.",
             );
             std::fs::create_dir_all(&db_dir)?;
         } else {
             debug!(
-                "Using a temp directory to store persistent cache: {}",
-                db_dir.display()
+                directory = %db_dir,
+                "Using a temp directory to store persistent cache.",
             );
         }
         Self::with_options(config, db_dir.join("redb"))
@@ -44,21 +44,15 @@ impl FirestorePersistentCacheBackend {
         data_file_path: PathBuf,
     ) -> FirestoreResult<Self> {
         if data_file_path.exists() {
-            debug!(
-                "Opening database for persistent cache {:?}...",
-                data_file_path
-            );
+            debug!(?data_file_path, "Opening database for persistent cache...",);
         } else {
-            debug!(
-                "Creating database for persistent cache {:?}...",
-                data_file_path
-            );
+            debug!(?data_file_path, "Creating database for persistent cache...",);
         }
 
         let mut db = Database::create(data_file_path)?;
 
         db.compact()?;
-        info!("Successfully opened database for persistent cache");
+        info!("Successfully opened database for persistent cache.");
 
         Ok(Self { config, redb: db })
     }
@@ -88,14 +82,18 @@ impl FirestorePersistentCacheBackend {
                     ) && existing_records > 0
                     {
                         info!(
-                                "Preloading collection `{}` has been skipped. Already loaded: {} entries",
-                                collection_path.as_str(),
-                                existing_records
-                            );
+                            collection_path = collection_path.as_str(),
+                            entries_loaded = existing_records,
+                            "Preloading collection has been skipped.",
+                        );
                         continue;
                     }
 
-                    debug!("Preloading {}", collection_path.as_str());
+                    debug!(
+                        collection_path = collection_path.as_str(),
+                        "Preloading collection."
+                    );
+
                     let params = if let Some(parent) = &config.parent {
                         db.fluent()
                             .select()
@@ -112,9 +110,9 @@ impl FirestorePersistentCacheBackend {
                         .map(|(index, docs)| {
                             if index > 0 && index % 5000 == 0 {
                                 debug!(
-                                    "Preloading collection `{}`: {} entries loaded",
-                                    collection_path.as_str(),
-                                    index
+                                    collection_path = collection_path.as_str(),
+                                    entries_loaded = index,
+                                    "Collection preload in progress...",
                                 );
                             }
                             docs
@@ -122,7 +120,7 @@ impl FirestorePersistentCacheBackend {
                         .ready_chunks(100)
                         .for_each(|docs| async move {
                             if let Err(err) = self.write_batch_docs(collection_path, docs) {
-                                error!("Error while preloading collection: {}", err);
+                                error!(err, "Error while preloading collection.");
                             }
                         })
                         .await;
@@ -140,16 +138,15 @@ impl FirestorePersistentCacheBackend {
                     };
 
                     info!(
-                        "Preloading collection `{}` has been finished. Loaded: {} entries",
-                        collection_path.as_str(),
-                        updated_records
+                        collection_path = collection_path.as_str(),
+                        updated_records, "Preloading collection has been finished.",
                     );
                 }
                 FirestoreCacheCollectionLoadMode::PreloadNone => {
                     let tx = self.redb.begin_write()?;
                     debug!(
-                        "Creating corresponding collection table `{}`",
                         collection_path
+                        "Creating corresponding collection table.",
                     );
                     tx.open_table(td)?;
                     tx.commit()?;
@@ -289,8 +286,8 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
             let write_txn = self.redb.begin_write()?;
             {
                 debug!(
-                    "Invalidating {} and draining the corresponding table",
-                    collection_path
+                    collection_path,
+                    "Invalidating collection and draining the corresponding table.",
                 );
                 let mut table = write_txn.open_table(td)?;
                 table.drain::<&str>(..)?;
@@ -310,9 +307,10 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
             FirestoreListenEvent::DocumentChange(doc_change) => {
                 if let Some(doc) = doc_change.document {
                     trace!(
-                        "Writing document to cache due to listener event: {:?}",
-                        doc.name
+                        doc_name = ?doc.name,
+                        "Writing document to cache due to listener event.",
                     );
+
                     self.write_document(&doc)?;
                 }
                 Ok(())
@@ -322,10 +320,12 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
                 let write_txn = self.redb.begin_write()?;
                 let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
                 let mut table = write_txn.open_table(td)?;
+
                 trace!(
-                    "Removing document from cache due to listener event: {:?}",
-                    doc_deleted.document.as_str()
+                    deleted_doc = ?doc_deleted.document.as_str(),
+                    "Removing document from cache due to listener event.",
                 );
+
                 table.remove(document_id)?;
                 Ok(())
             }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -108,7 +108,7 @@ where
                 let backend = backend.clone();
                 async move {
                     if let Err(err) = backend.on_listen_event(event).await {
-                        error!("Error occurred while updating cache: {}", err);
+                        error!(err, "Error occurred while updating cache.");
                     };
                     Ok(())
                 }
@@ -175,7 +175,7 @@ pub trait FirestoreCacheDocsByPathSupport {
                             Ok((doc_id, Some(document)))
                         }),
                         Err(err) => {
-                            error!("Error occurred while reading from cache: {}", err);
+                            error!(err, "Error occurred while reading from cache.");
                             None
                         }
                     }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -108,7 +108,7 @@ where
                 let backend = backend.clone();
                 async move {
                     if let Err(err) = backend.on_listen_event(event).await {
-                        error!(err, "Error occurred while updating cache.");
+                        error!(?err, "Error occurred while updating cache.");
                     };
                     Ok(())
                 }
@@ -175,7 +175,7 @@ pub trait FirestoreCacheDocsByPathSupport {
                             Ok((doc_id, Some(document)))
                         }),
                         Err(err) => {
-                            error!(err, "Error occurred while reading from cache.");
+                            error!(%err, "Error occurred while reading from cache.");
                             None
                         }
                     }

--- a/src/db/aggregated_query.rs
+++ b/src/db/aggregated_query.rs
@@ -181,7 +181,7 @@ impl FirestoreAggregatedQuerySupport for FirestoreDb {
                 Ok(Some(doc)) => Some(doc),
                 Ok(None) => None,
                 Err(err) => {
-                    error!("Error occurred while consuming query: {}", err);
+                    error!(%err, "Error occurred while consuming query.");
                     None
                 }
             })
@@ -210,7 +210,7 @@ impl FirestoreAggregatedQuerySupport for FirestoreDb {
                 Ok(Some(doc)) => Some(Ok(doc)),
                 Ok(None) => None,
                 Err(err) => {
-                    error!("Error occurred while consuming query: {}", err);
+                    error!(%err, "Error occurred while consuming query.");
                     Some(Err(err))
                 }
             })
@@ -244,8 +244,8 @@ impl FirestoreAggregatedQuerySupport for FirestoreDb {
                 Ok(obj) => Some(obj),
                 Err(err) => {
                     error!(
-                        "Error occurred while consuming query document as a stream: {}",
-                        err
+                        %err,
+                        "Error occurred while consuming query document as a stream.",
                     );
                     None
                 }
@@ -328,9 +328,9 @@ impl FirestoreDb {
                     );
                     span.in_scope(|| {
                         debug!(
-                            "Querying stream of documents in {:?} took {}ms",
-                            params.query_params.collection_id,
-                            query_duration.num_milliseconds()
+                            collection_id = ?params.query_params.collection_id,
+                            duration_milliseconds = query_duration.num_milliseconds(),
+                            "Querying stream of documents in specified collection.",
                         );
                     });
 
@@ -341,10 +341,10 @@ impl FirestoreDb {
                         if db_err.retry_possible && retries < self.inner.options.max_retries =>
                     {
                         warn!(
-                            "Failed with {}. Retrying: {}/{}",
-                            db_err,
-                            retries + 1,
-                            self.inner.options.max_retries
+                            err = %db_err,
+                            current_retry = retries + 1,
+                            max_retries = self.inner.options.max_retries,
+                            "Failed to run aggregation query. Retrying up to the specified number of times.",
                         );
 
                         self.stream_aggregated_query_doc_with_retries(params, retries + 1, span)
@@ -392,9 +392,9 @@ impl FirestoreDb {
                     );
                     span.in_scope(|| {
                         debug!(
-                            "Querying documents in {:?} took {}ms",
-                            params.query_params.collection_id,
-                            query_duration.num_milliseconds()
+                            collection_id = ?params.query_params.collection_id,
+                            duration_milliseconds = query_duration.num_milliseconds(),
+                            "Querying documents in specified collection.",
                         );
                     });
 
@@ -405,11 +405,12 @@ impl FirestoreDb {
                         if db_err.retry_possible && retries < self.inner.options.max_retries =>
                     {
                         warn!(
-                            "Failed with {}. Retrying: {}/{}",
-                            db_err,
-                            retries + 1,
-                            self.inner.options.max_retries
+                            err = %db_err,
+                            current_retry = retries + 1,
+                            max_retries = self.inner.options.max_retries,
+                            "Failed to run aggregation query. Retrying up to the specified number of times.",
                         );
+
                         self.aggregated_query_doc_with_retries(params, retries + 1, span)
                             .await
                     }

--- a/src/db/create.rs
+++ b/src/db/create.rs
@@ -130,9 +130,9 @@ impl FirestoreCreateSupport for FirestoreDb {
 
         span.in_scope(|| {
             debug!(
-                "Created a new document: {}/{:?}",
                 collection_id,
-                document_id.as_ref().map(|id| id.as_ref())
+                document_id = document_id.as_ref().map(|id| id.as_ref()),
+                "Created a new document.",
             );
         });
 

--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -84,9 +84,9 @@ impl FirestoreDeleteSupport for FirestoreDb {
 
         span.in_scope(|| {
             debug!(
-                "Deleted a document: {}/{}",
                 collection_id,
-                document_id.as_ref()
+                document_id = document_id.as_ref(),
+                "Deleted a document.",
             );
         });
 

--- a/src/db/listen_changes_state_storage.rs
+++ b/src/db/listen_changes_state_storage.rs
@@ -33,9 +33,10 @@ impl FirestoreTempFilesListenStateStorage {
 
     pub fn with_temp_dir<P: AsRef<std::path::Path>>(temp_dir: P) -> Self {
         debug!(
-            "Using temp dir for listen state storage: {:?}",
-            temp_dir.as_ref()
+            directory = ?temp_dir.as_ref(),
+            "Using temp dir for listen state storage.",
         );
+
         Self {
             temp_dir: Some(temp_dir.as_ref().to_path_buf()),
         }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -148,10 +148,10 @@ impl FirestoreDb {
             .unwrap_or_else(|| GOOGLE_FIREBASE_API_URL.to_string());
 
         info!(
-            "Creating a new DB client: {}. API: {} Token scopes: {}",
-            firestore_database_path,
-            effective_firebase_api_url,
-            token_scopes.join(", ")
+            database_path = firestore_database_path,
+            api_url = effective_firebase_api_url,
+            token_scopes = token_scopes.join(", "),
+            "Creating a new database client.",
         );
 
         let client = GoogleApiClient::from_function_with_token_source(

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -121,7 +121,7 @@ impl FirestoreDb {
                     );
                     span.in_scope(|| {
                         debug!(
-                            collection_id = params.collection_id,
+                            collection_id = ?params.collection_id,
                             duration_milliseconds = query_duration.num_milliseconds(),
                             "Queried stream of documents.",
                         );

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -121,9 +121,9 @@ impl FirestoreDb {
                     );
                     span.in_scope(|| {
                         debug!(
-                            "Querying stream of documents in {:?} took {}ms",
-                            params.collection_id,
-                            query_duration.num_milliseconds()
+                            collection_id = params.collection_id,
+                            duration_milliseconds = query_duration.num_milliseconds(),
+                            "Queried stream of documents.",
                         );
                     });
 
@@ -134,10 +134,10 @@ impl FirestoreDb {
                         if db_err.retry_possible && retries < self.inner.options.max_retries =>
                     {
                         warn!(
-                            "Failed with {}. Retrying: {}/{}",
-                            db_err,
-                            retries + 1,
-                            self.inner.options.max_retries
+                            err = %db_err,
+                            current_retry = retries + 1,
+                            max_retries = self.inner.options.max_retries,
+                            "Failed to stream query. Retrying up to the specified number of times.",
                         );
 
                         self.stream_query_doc_with_retries(params, retries + 1, span)
@@ -193,7 +193,7 @@ impl FirestoreDb {
                         FirestoreCachedValue::UseCached(stream) => {
                             span.record("/firestore/cache_result", "hit");
                             span.in_scope(|| {
-                                debug!("Querying {} documents from cache", collection_id);
+                                debug!(collection_id, "Querying documents from cache.");
                             });
                             Ok(FirestoreCachedValue::UseCached(stream))
                         }
@@ -204,9 +204,8 @@ impl FirestoreDb {
                                 FirestoreDbSessionCacheMode::ReadCachedOnly(_)
                             ) {
                                 span.in_scope(|| {
-                                    debug!(
-                                "Cache doesn't have suitable documents for {}, but cache mode is ReadCachedOnly so returning empty stream",
-                                collection_id.as_str()
+                                    debug!(collection_id,
+                                "Cache doesn't have suitable documents, but cache mode is ReadCachedOnly so returning empty stream.",
                             );
                                 });
                                 Ok(FirestoreCachedValue::UseCached(Box::pin(
@@ -215,8 +214,8 @@ impl FirestoreDb {
                             } else {
                                 span.in_scope(|| {
                                     debug!(
-                                        "Querying {} documents from cache skipped",
-                                        collection_id
+                                        collection_id,
+                                        "Querying documents from cache skipped.",
                                     );
                                 });
                                 Ok(FirestoreCachedValue::SkipCache)
@@ -248,7 +247,7 @@ impl FirestoreQuerySupport for FirestoreDb {
             future::ready(match doc_res {
                 Ok(doc) => Some(doc),
                 Err(err) => {
-                    error!("Error occurred while consuming query: {}", err);
+                    error!(%err, "Error occurred while consuming query.");
                     None
                 }
             })
@@ -284,7 +283,7 @@ impl FirestoreQuerySupport for FirestoreDb {
                 Ok(Some(doc)) => Some(Ok(doc)),
                 Ok(None) => None,
                 Err(err) => {
-                    error!("Error occurred while consuming query: {}", err);
+                    error!(%err, "Error occurred while consuming query.");
                     Some(Err(err))
                 }
             })
@@ -315,8 +314,8 @@ impl FirestoreQuerySupport for FirestoreDb {
                 Ok(obj) => Some(obj),
                 Err(err) => {
                     error!(
-                        "Error occurred while converting query document in a stream: {}",
-                        err
+                        %err,
+                        "Error occurred while converting query document in a stream.",
                     );
                     None
                 }
@@ -437,8 +436,8 @@ impl FirestoreQuerySupport for FirestoreDb {
 
         span.in_scope(|| {
             debug!(
-                "Running query on partitions with max parallelism: {}",
-                parallelism
+                parallelism,
+                "Running query on partitions with specified max parallelism.",
             )
         });
 
@@ -451,7 +450,7 @@ impl FirestoreQuerySupport for FirestoreDb {
         if cursors.is_empty() {
             span.in_scope(|| {
                 debug!(
-                    "The server detected the query has too few results to be partitioned. Falling back to normal query"
+                    "The server detected the query has too few results to be partitioned. Falling back to normal query."
                 )
             });
             let doc_stream = self
@@ -472,13 +471,18 @@ impl FirestoreQuerySupport for FirestoreDb {
                 mpsc::unbounded_channel::<FirestoreResult<(FirestorePartition, Document)>>();
 
             futures::stream::iter(cursors_pairs.windows(2))
-                .map(|cursor_pair| (cursor_pair, tx.clone(), partition_params.clone(), span.clone()))
+                .map(|cursor_pair| {
+                    (
+                        cursor_pair,
+                        tx.clone(),
+                        partition_params.clone(),
+                        span.clone(),
+                    )
+                })
                 .for_each_concurrent(
                     Some(parallelism),
                     |(cursor_pair, tx, partition_params, span)| async move {
-                        span.in_scope(|| {
-                            debug!("Streaming partition cursor {:?}",cursor_pair)
-                        });
+                        span.in_scope(|| debug!(?cursor_pair, "Streaming partition cursor."));
 
                         let mut params_with_cursors = partition_params.query_params;
                         if let Some(first_cursor) = cursor_pair.first() {
@@ -488,40 +492,45 @@ impl FirestoreQuerySupport for FirestoreDb {
                             params_with_cursors.mopt_end_at(last_cursor.clone());
                         }
 
-                        let partition = FirestorePartition::new().opt_start_at(params_with_cursors.start_at.clone()).opt_end_at(params_with_cursors.end_at.clone());
+                        let partition = FirestorePartition::new()
+                            .opt_start_at(params_with_cursors.start_at.clone())
+                            .opt_end_at(params_with_cursors.end_at.clone());
 
                         match self.stream_query_doc_with_errors(params_with_cursors).await {
                             Ok(result_stream) => {
                                 result_stream
-                                    .map(|doc_res| (doc_res, tx.clone(), span.clone(), partition.clone()))
+                                    .map(|doc_res| {
+                                        (doc_res, tx.clone(), span.clone(), partition.clone())
+                                    })
                                     .for_each(|(doc_res, tx, span, partition)| async move {
-
                                         let message = doc_res.map(|doc| (partition.clone(), doc));
                                         if let Err(err) = tx.send(message) {
                                             span.in_scope(|| {
                                                 warn!(
-                                                    "Unable to send result for partition {:?}:{:?}",
-                                                    partition,
-                                                    err
+                                                    %err,
+                                                    ?partition,
+                                                    "Unable to send result for partition.",
                                                 )
                                             })
                                         };
-                                    }).await;
-                            },
+                                    })
+                                    .await;
+                            }
                             Err(err) => {
                                 if let Err(err) = tx.send(Err(err)) {
                                     span.in_scope(|| {
                                         warn!(
-                                                "Unable to send result for partition cursor {:?} error {:?}",
-                                                cursor_pair,
-                                                err
-                                            )
+                                            ?err,
+                                            ?cursor_pair,
+                                            "Unable to send result for partition cursor.",
+                                        )
                                     })
                                 };
                             }
                         }
                     },
-                ).await;
+                )
+                .await;
 
             Ok(Box::pin(
                 tokio_stream::wrappers::UnboundedReceiverStream::new(rx),

--- a/src/db/update.rs
+++ b/src/db/update.rs
@@ -154,7 +154,7 @@ impl FirestoreUpdateSupport for FirestoreDb {
         );
 
         span.in_scope(|| {
-            debug!("Updated the document: {}/{}", collection_id, document_id);
+            debug!(collection_id, document_id, "Updated the document.");
         });
 
         Ok(update_response.into_inner())

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -39,7 +39,7 @@ where
     for<'de> T: Deserialize<'de>,
     DF: Fn(&T) -> String,
 {
-    info!("Populating {} collection", collection_name);
+    info!(collection_name, "Populating collection.".);
     let batch_writer = db.create_simple_batch_writer().await?;
     let mut current_batch = batch_writer.new_batch();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -39,7 +39,7 @@ where
     for<'de> T: Deserialize<'de>,
     DF: Fn(&T) -> String,
 {
-    info!(collection_name, "Populating collection.".);
+    info!(collection_name, "Populating collection.");
     let batch_writer = db.create_simple_batch_writer().await?;
     let mut current_batch = batch_writer.new_batch();
 


### PR DESCRIPTION
Hey again!

This PR goes through all of the places that the crate uses tracing events and pushes all of the variable data into fields.

This is something that we recently did for our backend services, and it made it far easier to analyze our logs using Google's Log Analytics tool. We're also able to easily pull out data from these fields, which is helpful not only for Log Analytics, but for log-based metrics!

We actually run our services with debug-level logging enabled for the firestore crate in order to get better insight into the behavior and performance of the database, and track down cases of transaction contention, which is why I've made this PR.

The root-level documentation of tracing has additional explanation of the merits of using fields [here](https://docs.rs/tracing/latest/tracing/#recording-fields).

Below is an example of what this looks like in Log Analytics for one of our services. This maybe isn't the best example because I've picked a small sample so I didn't have to draw so many black boxes, but you can see where some firestore events haven't been grouped.

![log_analytics_example](https://github.com/abdolence/firestore-rs/assets/2770254/34a8401f-c9e9-4a8c-b675-5e61b0dfef01)

Thank you for your continued, high quality work on this project!