### PR TITLE
Fix explicit null value serialization for timestamps

### DIFF
--- a/src/firestore_serde/timestamp_serializers.rs
+++ b/src/firestore_serde/timestamp_serializers.rs
@@ -71,13 +71,10 @@ pub mod serialize_as_null_timestamp {
     where
         S: Serializer,
     {
-        match date {
-            Some(v) => serializer.serialize_newtype_struct(
-                crate::firestore_serde::FIRESTORE_TS_NULL_TYPE_TAG_TYPE,
-                v,
-            ),
-            None => serializer.serialize_none(),
-        }
+        serializer.serialize_newtype_struct(
+            crate::firestore_serde::FIRESTORE_TS_NULL_TYPE_TAG_TYPE,
+            date,
+        )
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>


### PR DESCRIPTION
If `#[serde(with = "firestore::serialize_as_null_timestamp")]` is specified, `None` is not serialized to `null`.
