### PR TITLE
Handle dropped listener

### DIFF
--- a/src/db/listen_changes.rs
+++ b/src/db/listen_changes.rs
@@ -390,7 +390,11 @@ where
                 }
                 Ok(mut listen_stream) => loop {
                     tokio::select! {
-                        _ = shutdown_receiver.recv() => {
+                        shutdown_trigger = shutdown_receiver.recv() => {
+                            if shutdown_trigger.is_none() {
+                                debug!("Listener dropped. Exiting...");
+                                shutdown_flag.store(true, Ordering::Relaxed);
+                            }
                             debug!(num_targets = targets_state.len(), "Exiting from listener on targets...");
                             shutdown_receiver.close();
                             break;


### PR DESCRIPTION
Hi, I'd like to propose a small addition.

I've noticed that dropping a listener after starting to listen to changes causes its internal loop to be stuck in a tight loop:
```
2024-03-18T07:42:11.255745Z DEBUG firestore::db::listen_changes: Exiting from listener on targets... num_targets=2
2024-03-18T07:42:11.255754Z DEBUG firestore::db::listen_changes: Start listening on targets... num_targets=2
2024-03-18T07:42:11.256078Z DEBUG firestore::db::listen_changes: Exiting from listener on targets... num_targets=2
2024-03-18T07:42:11.256087Z DEBUG firestore::db::listen_changes: Start listening on targets... num_targets=2
2024-03-18T07:42:11.256439Z DEBUG firestore::db::listen_changes: Exiting from listener on targets... num_targets=2
2024-03-18T07:42:11.256447Z DEBUG firestore::db::listen_changes: Start listening on targets... num_targets=2
...
```

The situation can be reproduced by dropping the listener in the `listen-changes` example instead of retaining it for `shutdown` like this:
```diff
diff --git a/examples/listen-changes.rs b/examples/listen-changes.rs
index a1adc1b..eac0776 100644
--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -94,6 +94,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             Ok(())
         })
         .await?;
+
+    drop(listener);
+
     // Wait any input until we shutdown
     println!(
         "Waiting any other changes. Try firebase console to change in {} now yourself. New doc created id: {:?}",
@@ -101,7 +104,5 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     );
     std::io::stdin().read(&mut [1])?;
 
-    listener.shutdown().await?;
-
     Ok(())
 }
```

I've found out that the call to `shutdown_receiver.recv()` doesn't check if the value is there (`recv` results in `None` if all senders have been dropped). I'm assuming that dropping the listener without calling `shutdown` is an error (so maybe the log I'm adding should be a warn/error?) but I believe it's still better to stop the loop instead of spinning.