### PR TITLE
feat: bump gcloud-sdk dependency to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tls-webpki-roots = ["gcloud-sdk/tls-webpki-roots"]
 
 [dependencies]
 tracing = "0.1"
-gcloud-sdk = { version = "0.29", default-features = false, features = ["google-firestore-v1"] }
+gcloud-sdk = { version = "0.30", default-features = false, features = ["google-firestore-v1"] }
 hyper = { version = "1" }
 struct-path = "0.2"
 rvstruct = "0.3.2"

--- a/src/firestore_serde/deserializer.rs
+++ b/src/firestore_serde/deserializer.rs
@@ -464,6 +464,7 @@ impl<'de> serde::Deserializer<'de> for FirestoreValue {
                     .collect();
                 visitor.visit_map(FirestoreValueMapAccess::new(pipeline_fields))
             }
+            Some(value::ValueType::VariableReferenceValue(v)) => visitor.visit_string(v),
             None => visitor.visit_unit(),
         }
     }


### PR DESCRIPTION
## Summary

- Bumps `gcloud-sdk` from 0.29 to 0.30
- Adds match arm for the new `VariableReferenceValue` variant in the serde deserializer

Closes #222