### PR TITLE
fix: support gcloud-sdk 0.30.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tls-webpki-roots = ["gcloud-sdk/tls-webpki-roots"]
 
 [dependencies]
 tracing = "0.1"
-gcloud-sdk = { version = "0.30", default-features = false, features = ["google-firestore-v1"] }
+gcloud-sdk = { version = "0.30.2", default-features = false, features = ["google-firestore-v1"] }
 hyper = { version = "1" }
 struct-path = "0.2"
 rvstruct = "0.3.2"

--- a/src/db/transaction_models.rs
+++ b/src/db/transaction_models.rs
@@ -64,6 +64,7 @@ impl TryFrom<FirestoreTransactionOptions>
                         gcloud_sdk::google::firestore::v1::transaction_options::Mode::ReadWrite(
                             gcloud_sdk::google::firestore::v1::transaction_options::ReadWrite {
                                 retry_transaction: vec![],
+                                concurrency_mode: gcloud_sdk::google::firestore::v1::transaction_options::ConcurrencyMode::Unspecified as i32,
                             },
                         ),
                     ),
@@ -75,6 +76,7 @@ impl TryFrom<FirestoreTransactionOptions>
                         gcloud_sdk::google::firestore::v1::transaction_options::Mode::ReadWrite(
                             gcloud_sdk::google::firestore::v1::transaction_options::ReadWrite {
                                 retry_transaction: tid,
+                                concurrency_mode: gcloud_sdk::google::firestore::v1::transaction_options::ConcurrencyMode::Unspecified as i32,
                             },
                         ),
                     ),


### PR DESCRIPTION
Fixes #226.

gcloud-sdk 0.30.2 regenerated the Firestore protos and `transaction_options::ReadWrite` gained a required `concurrency_mode` field, so the two initializers in `src/db/transaction_models.rs` no longer compile. This sets the field to `ConcurrencyMode::Unspecified`, which is the proto default and keeps the current behavior.

The `gcloud-sdk` requirement is bumped to `0.30.2` since the field does not exist in earlier versions.

Verified with `cargo check` against gcloud-sdk 0.30.2.