### PR TITLE
feat: Request tags support in native and fluent API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tls-webpki-roots = ["gcloud-sdk/tls-webpki-roots"]
 
 [dependencies]
 tracing = "0.1"
-gcloud-sdk = { version = "0.30.2", default-features = false, features = ["google-firestore-v1"] }
+gcloud-sdk = { version = "0.31.0", default-features = false, features = ["google-firestore-v1"] }
 hyper = { version = "1" }
 struct-path = "0.2"
 rvstruct = "0.3.2"
@@ -55,6 +55,7 @@ tokio = { version = "1", features = ["full"] }
 tempfile = "3"
 approx = "0.5"
 rustls = "0.23"
+jiff = "0.2"
 
 [[example]]
 name = "caching_memory_collections"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Library provides a simple API for Google Firestore based on the official gRPC AP
     - Streaming batch writes with automatic throttling to avoid time limits from Firestore;
     - K-nearest neighbor (KNN) vector search;
     - Explaining queries;
+    - Request tags to attribute Firestore usage;
 - Fluent high-level and strongly typed API;
 - Full async based on Tokio runtime;
 - Macro that helps you use JSON paths as references to your structure fields;
@@ -628,6 +629,53 @@ db.fluent()
   .stream_query_with_metadata()
   .await?;
 ```
+
+## Request tags
+
+Firestore supports attaching request tags to requests. They are reported by Firestore
+in its monitoring and billing breakdowns, which makes them useful to attribute reads
+and writes to a specific feature, tenant or background job.
+
+Tags can be set per operation for queries, aggregations, listings and listeners:
+
+```rust
+db.fluent()
+  .select()
+  .from(TEST_COLLECTION_NAME)
+  .request_tags(["nightly-report"])
+  // or use request_options if you want to provide the options structure directly
+  // .request_options(FirestoreRequestOptions::from_tags(["nightly-report"]))
+  .obj::<MyTestStructure>()
+  .query()
+  .await?;
+```
+
+Or session wide, for every request issued through a client instance. This is also how
+you attach tags to the CRUD operations (insert/update/delete/get):
+
+```rust
+let tagged_db = db.clone_with_request_tags(["nightly-report"]);
+
+tagged_db.fluent()
+  .insert()
+  .into(TEST_COLLECTION_NAME)
+  .document_id(&my_struct.some_id)
+  .object(&my_struct)
+  .execute::<MyTestStructure>()
+  .await?;
+```
+
+Transactions and batch writers accept them through their options:
+
+```rust
+db.run_transaction_with_options(
+    |db, tx| { /* ... */ },
+    FirestoreTransactionOptions::new()
+        .with_request_options(FirestoreRequestOptions::from_tags(["checkout"])),
+).await?;
+```
+
+A per operation value replaces the session wide default rather than merging with it.
 
 ## Google authentication
 

--- a/examples/request-tags.rs
+++ b/examples/request-tags.rs
@@ -1,0 +1,96 @@
+use chrono::{DateTime, Utc};
+use firestore::*;
+use futures::FutureExt;
+use serde::{Deserialize, Serialize};
+
+pub fn config_env_var(name: &str) -> Result<String, String> {
+    std::env::var(name).map_err(|e| format!("{name}: {e}"))
+}
+
+// Example structure to play with
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct MyTestStructure {
+    some_id: String,
+    some_string: String,
+    some_num: u64,
+    created_at: DateTime<Utc>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Logging with debug enabled
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter("firestore=debug")
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    // Create an instance
+    let db = FirestoreDb::new(&config_env_var("PROJECT_ID")?).await?;
+
+    const TEST_COLLECTION_NAME: &str = "test-request-tags";
+
+    let my_struct = MyTestStructure {
+        some_id: "test-1".to_string(),
+        some_string: "Test".to_string(),
+        some_num: 42,
+        created_at: Utc::now(),
+    };
+
+    // Request tags are attached to every request issued through this instance.
+    // This is also the way to tag the CRUD operations, which have no per operation
+    // options of their own.
+    let tagged_db = db.clone_with_request_tags(["nightly-report"]);
+
+    tagged_db
+        .fluent()
+        .delete()
+        .from(TEST_COLLECTION_NAME)
+        .document_id(&my_struct.some_id)
+        .execute()
+        .await?;
+
+    tagged_db
+        .fluent()
+        .insert()
+        .into(TEST_COLLECTION_NAME)
+        .document_id(&my_struct.some_id)
+        .object(&my_struct)
+        .execute::<MyTestStructure>()
+        .await?;
+
+    // Or per operation, overriding any session wide default
+    let objects: Vec<MyTestStructure> = db
+        .fluent()
+        .select()
+        .from(TEST_COLLECTION_NAME)
+        .request_tags(["hot-path", "tenant-42"])
+        // or use request_options to provide the options structure directly
+        // .request_options(FirestoreRequestOptions::from_tags(["hot-path"]))
+        .obj()
+        .query()
+        .await?;
+
+    println!("Found {} objects", objects.len());
+
+    // Transactions carry them through their options
+    db.run_transaction_with_options(
+        |db, _transaction| {
+            async move {
+                db.fluent()
+                    .select()
+                    .by_id_in(TEST_COLLECTION_NAME)
+                    .obj::<MyTestStructure>()
+                    .one("test-1")
+                    .await?;
+
+                Ok(())
+            }
+            .boxed()
+        },
+        FirestoreTransactionOptions::new()
+            .with_request_options(FirestoreRequestOptions::from_tags(["checkout"])),
+    )
+    .await?;
+
+    Ok(())
+}

--- a/examples/token_auth.rs
+++ b/examples/token_auth.rs
@@ -25,7 +25,7 @@ async fn my_token() -> gcloud_sdk::error::Result<gcloud_sdk::Token> {
         config_env_var("TOKEN_VALUE")
             .expect("TOKEN_VALUE must be specified")
             .into(),
-        chrono::Utc::now().add(std::time::Duration::from_secs(3600)),
+        jiff::Timestamp::now().add(std::time::Duration::from_secs(3600)),
     ))
 }
 

--- a/src/db/aggregated_query.rs
+++ b/src/db/aggregated_query.rs
@@ -287,6 +287,8 @@ impl FirestoreDb {
                 .as_ref()
                 .map(|selector| selector.try_into())
                 .transpose()?,
+            request_options: self
+                .resolve_request_options(params.query_params.request_options.as_ref()),
             query_type: Some(run_aggregation_query_request::QueryType::StructuredAggregationQuery(
                 StructuredAggregationQuery {
                     aggregations: params.aggregations.iter().map(|agg| agg.into()).collect(),

--- a/src/db/batch_simple_writer.rs
+++ b/src/db/batch_simple_writer.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
 use crate::{
     FirestoreBatch, FirestoreBatchWriteResponse, FirestoreBatchWriter, FirestoreDb,
-    FirestoreResult, FirestoreWriteResult,
+    FirestoreRequestOptions, FirestoreResult, FirestoreWriteResult,
 };
 use async_trait::async_trait;
 use futures::TryFutureExt;
@@ -13,6 +13,9 @@ use tracing::*;
 #[derive(Debug, Eq, PartialEq, Clone, Builder)]
 pub struct FirestoreSimpleBatchWriteOptions {
     retry_max_elapsed_time: Option<chrono::Duration>,
+
+    /// Request options (e.g. request tags) for the batch write requests.
+    pub request_options: Option<FirestoreRequestOptions>,
 }
 
 pub struct FirestoreSimpleBatchWriter {
@@ -58,6 +61,9 @@ impl FirestoreBatchWriter for FirestoreSimpleBatchWriter {
             database: self.db.get_database_path().to_string(),
             writes,
             labels: HashMap::new(),
+            request_options: self
+                .db
+                .resolve_request_options(self.options.request_options.as_ref()),
         };
 
         backoff::future::retry(backoff, || {

--- a/src/db/batch_streaming_writer.rs
+++ b/src/db/batch_streaming_writer.rs
@@ -1,6 +1,6 @@
 use crate::{
     FirestoreBatch, FirestoreBatchWriteResponse, FirestoreBatchWriter, FirestoreDb,
-    FirestoreResult, FirestoreWriteResult,
+    FirestoreRequestOptions, FirestoreResult, FirestoreWriteResult,
 };
 use async_trait::async_trait;
 use futures::stream::BoxStream;
@@ -22,6 +22,9 @@ use tracing::*;
 pub struct FirestoreStreamingBatchWriteOptions {
     #[default = "Duration::from_millis(500)"]
     pub throttle_batch_duration: Duration,
+
+    /// Request options (e.g. request tags) for the streaming write requests.
+    pub request_options: Option<FirestoreRequestOptions>,
 }
 
 pub struct FirestoreStreamingBatchWriter {
@@ -200,6 +203,7 @@ impl FirestoreStreamingBatchWriter {
             writes: vec![],
             stream_token: vec![],
             labels: HashMap::new(),
+            request_options: db.resolve_request_options(options.request_options.as_ref()),
         })?;
 
         init_wait_reader.recv().await;
@@ -250,6 +254,9 @@ impl FirestoreStreamingBatchWriter {
                         locked.clone()
                     },
                     labels: HashMap::new(),
+                    request_options: self
+                        .db
+                        .resolve_request_options(self.options.request_options.as_ref()),
                 })
                 .ok();
         } else {
@@ -277,6 +284,9 @@ impl FirestoreStreamingBatchWriter {
                 locked.clone()
             },
             labels: HashMap::new(),
+            request_options: self
+                .db
+                .resolve_request_options(self.options.request_options.as_ref()),
         })?)
     }
 

--- a/src/db/create.rs
+++ b/src/db/create.rs
@@ -106,6 +106,7 @@ impl FirestoreCreateSupport for FirestoreDb {
             }),
             collection_id: collection_id.into(),
             document: Some(input_doc),
+            request_options: self.resolve_request_options(None),
         });
 
         let begin_query_utc: DateTime<Utc> = Utc::now();

--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -70,6 +70,7 @@ impl FirestoreDeleteSupport for FirestoreDb {
         let request = gcloud_sdk::tonic::Request::new(DeleteDocumentRequest {
             name: document_path,
             current_document: precondition.map(|cond| cond.try_into()).transpose()?,
+            request_options: self.resolve_request_options(None),
         });
 
         let begin_query_utc: DateTime<Utc> = Utc::now();

--- a/src/db/get.rs
+++ b/src/db/get.rs
@@ -588,6 +588,7 @@ impl FirestoreDb {
                     .as_ref()
                     .map(|selector| selector.try_into())
                     .transpose()?,
+                request_options: self.resolve_request_options(None),
                 mask: return_only_fields.map({
                     |vf| gcloud_sdk::google::firestore::v1::DocumentMask {
                         field_paths: vf.iter().map(|f| f.to_string()).collect(),
@@ -692,6 +693,7 @@ impl FirestoreDb {
                 .as_ref()
                 .map(|selector| selector.try_into())
                 .transpose()?,
+            request_options: self.resolve_request_options(None),
             mask: return_only_fields.map({
                 |vf| gcloud_sdk::google::firestore::v1::DocumentMask {
                     field_paths: vf.iter().map(|f| f.to_string()).collect(),

--- a/src/db/list.rs
+++ b/src/db/list.rs
@@ -28,6 +28,9 @@ pub struct FirestoreListDocParams {
     pub page_token: Option<String>,
     pub order_by: Option<Vec<FirestoreQueryOrder>>,
     pub return_only_fields: Option<Vec<String>>,
+
+    /// Request options (e.g. request tags) for this listing operation.
+    pub request_options: Option<FirestoreRequestOptions>,
 }
 
 #[derive(Debug, PartialEq, Clone, Builder)]
@@ -43,6 +46,9 @@ pub struct FirestoreListCollectionIdsParams {
     #[default = "100"]
     pub page_size: usize,
     pub page_token: Option<String>,
+
+    /// Request options (e.g. request tags) for this listing operation.
+    pub request_options: Option<FirestoreRequestOptions>,
 }
 
 #[derive(Debug, PartialEq, Clone, Builder)]
@@ -287,6 +293,7 @@ impl FirestoreDb {
                 .as_ref()
                 .map(|selector| selector.try_into())
                 .transpose()?,
+            request_options: self.resolve_request_options(params.request_options.as_ref()),
             show_missing: false,
         })
     }
@@ -466,6 +473,7 @@ impl FirestoreDb {
                 .as_ref()
                 .map(|selector| selector.try_into())
                 .transpose()?,
+            request_options: self.resolve_request_options(params.request_options.as_ref()),
         }))
     }
 

--- a/src/db/listen_changes.rs
+++ b/src/db/listen_changes.rs
@@ -1,7 +1,10 @@
 use crate::db::safe_document_path;
 use crate::errors::*;
 use crate::timestamp_utils::to_timestamp;
-use crate::{FirestoreDb, FirestoreQueryParams, FirestoreResult, FirestoreResumeStateStorage};
+use crate::{
+    FirestoreDb, FirestoreQueryParams, FirestoreRequestOptions, FirestoreResult,
+    FirestoreResumeStateStorage,
+};
 pub use async_trait::async_trait;
 use chrono::prelude::*;
 use futures::stream::BoxStream;
@@ -26,6 +29,9 @@ pub struct FirestoreListenerTargetParams {
     pub resume_type: Option<FirestoreListenerTargetResumeType>,
     pub add_target_once: Option<bool>,
     pub labels: HashMap<String, String>,
+
+    /// Request options (e.g. request tags) for the listen requests of this target.
+    pub request_options: Option<FirestoreRequestOptions>,
 }
 
 impl FirestoreListenerTargetParams {
@@ -180,6 +186,7 @@ impl FirestoreDb {
         Ok(ListenRequest {
             database: self.get_database_path().to_string(),
             labels: target_params.labels,
+            request_options: self.resolve_request_options(target_params.request_options.as_ref()),
             target_change: Some(listen_request::TargetChange::AddTarget(Target {
                 target_id: target_params.target.try_into()?,
                 once: target_params.add_target_once.unwrap_or(false),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -78,6 +78,10 @@ pub use session_params::*;
 mod consistency_selector;
 pub use consistency_selector::*;
 
+/// Module for per-request options (e.g., request tags).
+mod request_options;
+pub use request_options::*;
+
 /// Module for building parent paths for sub-collections.
 mod parent_path_builder;
 pub use parent_path_builder::*;
@@ -428,6 +432,22 @@ impl FirestoreDb {
         &self.session_params
     }
 
+    /// Resolves the effective request options for an operation.
+    ///
+    /// A per operation override takes precedence over the session wide default
+    /// configured with
+    /// [`clone_with_request_options`](FirestoreDb::clone_with_request_options).
+    #[inline]
+    pub(crate) fn resolve_request_options(
+        &self,
+        request_options: Option<&FirestoreRequestOptions>,
+    ) -> Option<gcloud_sdk::google::firestore::v1::RequestOptions> {
+        FirestoreRequestOptions::resolve(
+            request_options,
+            self.session_params.request_options.as_ref(),
+        )
+    }
+
     /// Returns a reference to the underlying gRPC client.
     ///
     /// This provides access to the raw `FirestoreClient` from the `gcloud-sdk`
@@ -485,6 +505,82 @@ impl FirestoreDb {
         self.clone_with_session_params(
             existing_session_params.with_consistency_selector(consistency_selector),
         )
+    }
+
+    /// Clones the `FirestoreDb` instance with default request options.
+    ///
+    /// Every request issued through the returned instance carries these options,
+    /// unless an operation overrides them explicitly.
+    ///
+    /// # Arguments
+    /// * `request_options`: The [`FirestoreRequestOptions`] to apply by default.
+    #[inline]
+    pub fn clone_with_request_options(&self, request_options: FirestoreRequestOptions) -> Self {
+        let existing_session_params = (*self.session_params).clone();
+
+        self.clone_with_session_params(
+            existing_session_params.with_request_options(request_options),
+        )
+    }
+
+    /// Clones the `FirestoreDb` instance with default request tags.
+    ///
+    /// A convenience shortcut for
+    /// [`clone_with_request_options`](FirestoreDb::clone_with_request_options).
+    /// This is also the way to attach request tags to the CRUD operations
+    /// (get/create/update/delete), which have no per operation options.
+    ///
+    /// # Arguments
+    /// * `request_tags`: An iterator of tags to attach to every request.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use firestore::*;
+    /// # async fn run() -> FirestoreResult<()> {
+    /// let db = FirestoreDb::new("my-gcp-project-id").await?;
+    /// let tagged_db = db.clone_with_request_tags(["nightly-report"]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn clone_with_request_tags<I>(&self, request_tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<FirestoreRequestTag>,
+    {
+        self.clone_with_request_options(FirestoreRequestOptions::from_tags(request_tags))
+    }
+
+    /// Consumes the `FirestoreDb` instance and returns a new one with default
+    /// request options.
+    ///
+    /// # Arguments
+    /// * `request_options`: The [`FirestoreRequestOptions`] to apply by default.
+    #[inline]
+    pub fn with_request_options(self, request_options: FirestoreRequestOptions) -> Self {
+        let session_params = (*self.session_params)
+            .clone()
+            .with_request_options(request_options);
+
+        self.with_session_params(session_params)
+    }
+
+    /// Consumes the `FirestoreDb` instance and returns a new one with default
+    /// request tags.
+    ///
+    /// A convenience shortcut for
+    /// [`with_request_options`](FirestoreDb::with_request_options).
+    ///
+    /// # Arguments
+    /// * `request_tags`: An iterator of tags to attach to every request.
+    #[inline]
+    pub fn with_request_tags<I>(self, request_tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<FirestoreRequestTag>,
+    {
+        self.with_request_options(FirestoreRequestOptions::from_tags(request_tags))
     }
 
     /// Clones the `FirestoreDb` instance with a specific cache mode.

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -104,6 +104,7 @@ impl FirestoreDb {
                 .as_ref()
                 .map(|eo| eo.try_into())
                 .transpose()?,
+            request_options: self.resolve_request_options(params.request_options.as_ref()),
             query_type: Some(run_query_request::QueryType::StructuredQuery(
                 params.try_into()?,
             )),
@@ -440,6 +441,9 @@ impl FirestoreQuerySupport for FirestoreDb {
                                                 .unwrap_or_else(|| self.get_documents_path())
                                                 .clone(),
                                             consistency_selector: maybe_consistency_selector,
+                                            request_options: self.resolve_request_options(
+                                                params.query_params.request_options.as_ref(),
+                                            ),
                                             query_type: Some(
                                                 partition_query_request::QueryType::StructuredQuery(
                                                     query_params,

--- a/src/db/query_models.rs
+++ b/src/db/query_models.rs
@@ -5,7 +5,7 @@
 use crate::errors::{
     FirestoreError, FirestoreInvalidParametersError, FirestoreInvalidParametersPublicDetails,
 };
-use crate::{FirestoreValue, FirestoreVector};
+use crate::{FirestoreRequestOptions, FirestoreValue, FirestoreVector};
 use gcloud_sdk::google::firestore::v1::*;
 use rsb_derive::Builder;
 
@@ -86,6 +86,12 @@ pub struct FirestoreQueryParams {
 
     /// Options for performing a vector similarity search (find nearest neighbors).
     pub find_nearest: Option<FirestoreFindNearestOptions>,
+
+    /// Request options (e.g. request tags) for this query.
+    ///
+    /// Overrides any session wide default configured with
+    /// [`FirestoreDb::clone_with_request_options`](crate::FirestoreDb::clone_with_request_options).
+    pub request_options: Option<FirestoreRequestOptions>,
 }
 
 impl TryFrom<FirestoreQueryParams> for StructuredQuery {

--- a/src/db/request_options.rs
+++ b/src/db/request_options.rs
@@ -1,0 +1,197 @@
+use rsb_derive::Builder;
+use rvstruct::ValueStruct;
+
+/// A single request tag attached to a Firestore request.
+///
+/// Request tags are arbitrary strings that Firestore associates with a request and
+/// reports back in its monitoring and billing breakdowns. This makes them useful to
+/// attribute reads and writes to a particular feature, tenant or background job.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, ValueStruct)]
+pub struct FirestoreRequestTag(String);
+
+/// Options attached to an individual Firestore server request.
+///
+/// Request options can be specified:
+/// - session wide, for every request issued by a [`FirestoreDb`](crate::FirestoreDb)
+///   instance, using
+///   [`FirestoreDb::clone_with_request_tags()`](crate::FirestoreDb::clone_with_request_tags)
+///   or
+///   [`FirestoreDb::clone_with_request_options()`](crate::FirestoreDb::clone_with_request_options);
+/// - per operation, on the params structures such as
+///   [`FirestoreQueryParams`](crate::FirestoreQueryParams), or through the
+///   `request_tags()` / `request_options()` methods of the fluent API.
+///
+/// A per operation value replaces the session wide default rather than merging
+/// with it.
+///
+/// # Examples
+///
+/// ```rust
+/// use firestore::*;
+///
+/// let options = FirestoreRequestOptions::from_tags(["checkout", "tenant-42"]);
+///
+/// assert_eq!(
+///     options.request_tags,
+///     vec![
+///         FirestoreRequestTag::from("checkout"),
+///         FirestoreRequestTag::from("tenant-42"),
+///     ]
+/// );
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Builder)]
+pub struct FirestoreRequestOptions {
+    /// The request tags for the request.
+    ///
+    /// Defaults to an empty list, which is equivalent to sending no tags at all.
+    #[default = "Vec::new()"]
+    pub request_tags: Vec<FirestoreRequestTag>,
+}
+
+impl FirestoreRequestOptions {
+    /// Creates request options from an iterator of tags.
+    ///
+    /// # Arguments
+    /// * `tags`: An iterator of anything convertible into a [`FirestoreRequestTag`],
+    ///   such as `&str` or `String`.
+    #[inline]
+    pub fn from_tags<I>(tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<FirestoreRequestTag>,
+    {
+        Self {
+            request_tags: tags.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Resolves the effective request options for a single operation.
+    ///
+    /// A per operation override takes precedence over the session wide default.
+    /// Returns `None` when the resolved options carry no tags, so that no request
+    /// options are attached to the request at all.
+    #[inline]
+    pub(crate) fn resolve(
+        operation_options: Option<&FirestoreRequestOptions>,
+        session_options: Option<&FirestoreRequestOptions>,
+    ) -> Option<gcloud_sdk::google::firestore::v1::RequestOptions> {
+        operation_options
+            .or(session_options)
+            .filter(|options| !options.request_tags.is_empty())
+            .map(|options| options.into())
+    }
+}
+
+impl From<&FirestoreRequestOptions> for gcloud_sdk::google::firestore::v1::RequestOptions {
+    fn from(options: &FirestoreRequestOptions) -> Self {
+        gcloud_sdk::google::firestore::v1::RequestOptions {
+            request_tags: options
+                .request_tags
+                .iter()
+                .map(|tag| tag.value().clone())
+                .collect(),
+        }
+    }
+}
+
+impl From<FirestoreRequestOptions> for gcloud_sdk::google::firestore::v1::RequestOptions {
+    fn from(options: FirestoreRequestOptions) -> Self {
+        gcloud_sdk::google::firestore::v1::RequestOptions {
+            request_tags: options
+                .request_tags
+                .into_iter()
+                .map(|tag| tag.into_value())
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_tag_from_str() {
+        let tag: FirestoreRequestTag = "checkout".into();
+        assert_eq!(tag.value(), "checkout");
+    }
+
+    #[test]
+    fn test_request_options_from_tags() {
+        let options = FirestoreRequestOptions::from_tags(["tag-1", "tag-2"]);
+
+        assert_eq!(
+            options.request_tags,
+            vec![
+                FirestoreRequestTag::from("tag-1"),
+                FirestoreRequestTag::from("tag-2"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_request_options_new_is_empty() {
+        assert!(FirestoreRequestOptions::new().request_tags.is_empty());
+    }
+
+    #[test]
+    fn test_request_options_conversion() {
+        let options = FirestoreRequestOptions::from_tags(["a", "b"]);
+
+        let proto: gcloud_sdk::google::firestore::v1::RequestOptions = (&options).into();
+        assert_eq!(proto.request_tags, vec!["a".to_string(), "b".to_string()]);
+
+        let owned_proto: gcloud_sdk::google::firestore::v1::RequestOptions = options.into();
+        assert_eq!(
+            owned_proto.request_tags,
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_resolve_prefers_operation_options() {
+        let operation_options = FirestoreRequestOptions::from_tags(["operation"]);
+        let session_options = FirestoreRequestOptions::from_tags(["session"]);
+
+        assert_eq!(
+            FirestoreRequestOptions::resolve(Some(&operation_options), Some(&session_options))
+                .map(|options| options.request_tags),
+            Some(vec!["operation".to_string()])
+        );
+
+        assert_eq!(
+            FirestoreRequestOptions::resolve(None, Some(&session_options))
+                .map(|options| options.request_tags),
+            Some(vec!["session".to_string()])
+        );
+
+        assert_eq!(
+            FirestoreRequestOptions::resolve(Some(&operation_options), None)
+                .map(|options| options.request_tags),
+            Some(vec!["operation".to_string()])
+        );
+
+        assert_eq!(FirestoreRequestOptions::resolve(None, None), None);
+    }
+
+    #[test]
+    fn test_resolve_skips_empty_tags() {
+        let empty_options = FirestoreRequestOptions::new();
+        let session_options = FirestoreRequestOptions::from_tags(["session"]);
+
+        // Nothing configured at all: no request options on the wire.
+        assert_eq!(FirestoreRequestOptions::resolve(None, None), None);
+
+        // Explicitly empty options are still an override, they clear the session
+        // wide tags instead of falling back to them, and nothing is sent.
+        assert_eq!(
+            FirestoreRequestOptions::resolve(Some(&empty_options), Some(&session_options)),
+            None
+        );
+
+        assert_eq!(
+            FirestoreRequestOptions::resolve(None, Some(&empty_options)),
+            None
+        );
+    }
+}

--- a/src/db/session_params.rs
+++ b/src/db/session_params.rs
@@ -1,4 +1,4 @@
-use crate::FirestoreConsistencySelector;
+use crate::{FirestoreConsistencySelector, FirestoreRequestOptions};
 use rsb_derive::*;
 
 /// Parameters that define the behavior of a Firestore session or a specific set of operations.
@@ -27,6 +27,13 @@ pub struct FirestoreDbSessionParams {
     /// This field is only effective if the `caching` feature is enabled.
     #[default = "FirestoreDbSessionCacheMode::None"]
     pub cache_mode: FirestoreDbSessionCacheMode,
+
+    /// Default [`FirestoreRequestOptions`] (e.g. request tags) applied to every
+    /// request issued with this session.
+    ///
+    /// Individual operations may override this value. If `None` (the default),
+    /// no request options are attached to the requests.
+    pub request_options: Option<FirestoreRequestOptions>,
 }
 
 /// Defines the caching mode for Firestore operations within a session.

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -2,8 +2,8 @@ pub use crate::db::transaction_ops::FirestoreTransactionOps;
 use crate::errors::*;
 use crate::timestamp_utils::from_timestamp;
 use crate::{
-    FirestoreConsistencySelector, FirestoreDb, FirestoreError, FirestoreResult,
-    FirestoreTransactionId, FirestoreTransactionMode, FirestoreTransactionOptions,
+    FirestoreConsistencySelector, FirestoreDb, FirestoreError, FirestoreRequestOptions,
+    FirestoreResult, FirestoreTransactionId, FirestoreTransactionMode, FirestoreTransactionOptions,
     FirestoreTransactionResponse, FirestoreWriteResult,
 };
 use backoff::future::retry;
@@ -88,6 +88,7 @@ pub struct FirestoreTransaction<'a> {
     db: &'a FirestoreDb,
     data: FirestoreTransactionData,
     finished: bool,
+    request_options: Option<FirestoreRequestOptions>,
 }
 
 impl<'a> FirestoreTransaction<'a> {
@@ -105,6 +106,7 @@ impl<'a> FirestoreTransaction<'a> {
         let request = gcloud_sdk::tonic::Request::new(BeginTransactionRequest {
             database: db.get_database_path().clone(),
             options: Some(options.clone().try_into()?),
+            request_options: db.resolve_request_options(options.request_options.as_ref()),
         });
 
         let response = db
@@ -134,6 +136,7 @@ impl<'a> FirestoreTransaction<'a> {
             db,
             data,
             finished: false,
+            request_options: options.request_options,
         })
     }
 
@@ -160,6 +163,9 @@ impl<'a> FirestoreTransaction<'a> {
             database: self.db.get_database_path().clone(),
             writes: self.data.writes.drain(..).collect(),
             transaction: self.data.transaction_id.clone(),
+            request_options: self
+                .db
+                .resolve_request_options(self.request_options.as_ref()),
         });
 
         let response = self.db.client().get().commit(request).await?.into_inner();
@@ -191,6 +197,9 @@ impl<'a> FirestoreTransaction<'a> {
         let request = gcloud_sdk::tonic::Request::new(RollbackRequest {
             database: self.db.get_database_path().clone(),
             transaction: self.data.transaction_id.clone(),
+            request_options: self
+                .db
+                .resolve_request_options(self.request_options.as_ref()),
         });
 
         self.db.client().get().rollback(request).await?;
@@ -228,6 +237,7 @@ impl<'a> FirestoreTransaction<'a> {
             db,
             data,
             finished: false,
+            request_options: None,
         }
     }
 
@@ -370,7 +380,7 @@ impl FirestoreDb {
         let retry_result = retry(backoff, || async {
             let options = FirestoreTransactionOptions {
                 mode: FirestoreTransactionMode::ReadWriteRetry(transaction_id.clone()),
-                ..options
+                ..options.clone()
             };
             let mut transaction = self
                 .begin_transaction_with_options(options)
@@ -438,7 +448,7 @@ impl FirestoreDb {
 
             let options = FirestoreTransactionOptions {
                 mode: FirestoreTransactionMode::ReadWriteRetry(transaction_id.clone()),
-                ..options
+                ..options.clone()
             };
             if let Ok(transaction) = self.begin_transaction_with_options(options).await {
                 transaction.rollback().await.ok();

--- a/src/db/transaction_models.rs
+++ b/src/db/transaction_models.rs
@@ -1,5 +1,5 @@
 use crate::errors::FirestoreError;
-use crate::{FirestoreConsistencySelector, FirestoreWriteResult};
+use crate::{FirestoreConsistencySelector, FirestoreRequestOptions, FirestoreWriteResult};
 use chrono::prelude::*;
 use chrono::Duration;
 use rsb_derive::Builder;
@@ -22,6 +22,10 @@ pub struct FirestoreTransactionOptions {
     /// Concurrent transaction mode
     pub concurrent_mode:
         Option<gcloud_sdk::google::firestore::v1::transaction_options::ConcurrencyMode>,
+
+    /// Request options (e.g. request tags) attached to the `BeginTransaction`,
+    /// `Commit` and `Rollback` requests of this transaction.
+    pub request_options: Option<FirestoreRequestOptions>,
 }
 
 impl Default for FirestoreTransactionOptions {
@@ -30,6 +34,7 @@ impl Default for FirestoreTransactionOptions {
             mode: FirestoreTransactionMode::ReadWrite,
             max_elapsed_time: None,
             concurrent_mode: None,
+            request_options: None,
         }
     }
 }
@@ -138,4 +143,24 @@ pub struct FirestoreTransactionResponse {
     /// The time at which the transaction was committed.
     /// This is `None` if the transaction was read-only or did not involve writes.
     pub commit_time: Option<DateTime<Utc>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transaction_options_default_request_options() {
+        assert!(FirestoreTransactionOptions::default()
+            .request_options
+            .is_none());
+
+        let options = FirestoreTransactionOptions::new()
+            .with_request_options(FirestoreRequestOptions::from_tags(["checkout"]));
+
+        assert_eq!(
+            options.request_options,
+            Some(FirestoreRequestOptions::from_tags(["checkout"]))
+        );
+    }
 }

--- a/src/db/update.rs
+++ b/src/db/update.rs
@@ -137,6 +137,7 @@ impl FirestoreUpdateSupport for FirestoreDb {
                 field_paths: masks.clone(),
             }),
             current_document: precondition.map(|cond| cond.try_into()).transpose()?,
+            request_options: self.resolve_request_options(None),
         });
 
         let begin_query_utc: DateTime<Utc> = Utc::now();

--- a/src/fluent_api/listing_builder.rs
+++ b/src/fluent_api/listing_builder.rs
@@ -6,7 +6,8 @@
 
 use crate::{
     FirestoreListCollectionIdsParams, FirestoreListCollectionIdsResult, FirestoreListDocParams,
-    FirestoreListDocResult, FirestoreListingSupport, FirestoreQueryOrder, FirestoreResult,
+    FirestoreListDocResult, FirestoreListingSupport, FirestoreQueryOrder, FirestoreRequestOptions,
+    FirestoreRequestTag, FirestoreResult,
 };
 use futures::stream::BoxStream;
 use gcloud_sdk::google::firestore::v1::Document;
@@ -195,6 +196,40 @@ where
         }
     }
 
+    /// Attaches request tags to this listing operation.
+    ///
+    /// They override any session wide default configured with
+    /// [`FirestoreDb::clone_with_request_tags()`](crate::FirestoreDb::clone_with_request_tags).
+    ///
+    /// # Arguments
+    /// * `request_tags`: An iterator of tags to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request tags set.
+    #[inline]
+    pub fn request_tags<I>(self, request_tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<FirestoreRequestTag>,
+    {
+        self.request_options(FirestoreRequestOptions::from_tags(request_tags))
+    }
+
+    /// Attaches request options to this listing operation.
+    ///
+    /// # Arguments
+    /// * `options`: The [`FirestoreRequestOptions`] to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request options set.
+    #[inline]
+    pub fn request_options(self, options: FirestoreRequestOptions) -> Self {
+        Self {
+            params: self.params.with_request_options(options),
+            ..self
+        }
+    }
+
     /// Retrieves a single page of documents.
     ///
     /// # Returns
@@ -256,6 +291,40 @@ where
             db,
             params,
             _pd: PhantomData,
+        }
+    }
+
+    /// Attaches request tags to this listing operation.
+    ///
+    /// They override any session wide default configured with
+    /// [`FirestoreDb::clone_with_request_tags()`](crate::FirestoreDb::clone_with_request_tags).
+    ///
+    /// # Arguments
+    /// * `request_tags`: An iterator of tags to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request tags set.
+    #[inline]
+    pub fn request_tags<I>(self, request_tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<FirestoreRequestTag>,
+    {
+        self.request_options(FirestoreRequestOptions::from_tags(request_tags))
+    }
+
+    /// Attaches request options to this listing operation.
+    ///
+    /// # Arguments
+    /// * `options`: The [`FirestoreRequestOptions`] to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request options set.
+    #[inline]
+    pub fn request_options(self, options: FirestoreRequestOptions) -> Self {
+        Self {
+            params: self.params.with_request_options(options),
+            ..self
         }
     }
 
@@ -349,6 +418,40 @@ where
         }
     }
 
+    /// Attaches request tags to this listing operation.
+    ///
+    /// They override any session wide default configured with
+    /// [`FirestoreDb::clone_with_request_tags()`](crate::FirestoreDb::clone_with_request_tags).
+    ///
+    /// # Arguments
+    /// * `request_tags`: An iterator of tags to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request tags set.
+    #[inline]
+    pub fn request_tags<I>(self, request_tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<FirestoreRequestTag>,
+    {
+        self.request_options(FirestoreRequestOptions::from_tags(request_tags))
+    }
+
+    /// Attaches request options to this listing operation.
+    ///
+    /// # Arguments
+    /// * `options`: The [`FirestoreRequestOptions`] to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request options set.
+    #[inline]
+    pub fn request_options(self, options: FirestoreRequestOptions) -> Self {
+        Self {
+            params: self.params.with_request_options(options),
+            ..self
+        }
+    }
+
     /// Retrieves a single page of collection IDs.
     ///
     /// # Returns
@@ -380,5 +483,38 @@ where
         self.db
             .stream_list_collection_ids_with_errors(self.params)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::fluent_api::tests::*;
+    use crate::fluent_api::FirestoreExprBuilder;
+    use crate::FirestoreRequestOptions;
+
+    #[test]
+    fn list_doc_builder_request_tags() {
+        let builder = FirestoreExprBuilder::new(&mockdb::MockDatabase {})
+            .list()
+            .from("test")
+            .request_tags(["tag-1", "tag-2"]);
+
+        assert_eq!(
+            builder.params.request_options,
+            Some(FirestoreRequestOptions::from_tags(["tag-1", "tag-2"]))
+        )
+    }
+
+    #[test]
+    fn list_collection_ids_builder_request_tags() {
+        let builder = FirestoreExprBuilder::new(&mockdb::MockDatabase {})
+            .list()
+            .collections()
+            .request_tags(["tag-1"]);
+
+        assert_eq!(
+            builder.params.request_options,
+            Some(FirestoreRequestOptions::from_tags(["tag-1"]))
+        )
     }
 }

--- a/src/fluent_api/select_builder.rs
+++ b/src/fluent_api/select_builder.rs
@@ -15,8 +15,9 @@ use crate::{
     FirestoreListener, FirestoreListenerParams, FirestoreListenerTarget,
     FirestoreListenerTargetParams, FirestorePartition, FirestorePartitionQueryParams,
     FirestoreQueryCollection, FirestoreQueryCursor, FirestoreQueryFilter, FirestoreQueryOrder,
-    FirestoreQueryParams, FirestoreQuerySupport, FirestoreResult, FirestoreResumeStateStorage,
-    FirestoreTargetType, FirestoreVector, FirestoreWithMetadata,
+    FirestoreQueryParams, FirestoreQuerySupport, FirestoreRequestOptions, FirestoreRequestTag,
+    FirestoreResult, FirestoreResumeStateStorage, FirestoreTargetType, FirestoreVector,
+    FirestoreWithMetadata,
 };
 use futures::stream::BoxStream;
 use gcloud_sdk::google::firestore::v1::Document;
@@ -372,6 +373,42 @@ where
         }
     }
 
+    /// Attaches request tags to this query.
+    ///
+    /// Request tags are reported by Firestore in its monitoring and billing
+    /// breakdowns, which makes them useful to attribute cost to a specific feature
+    /// or tenant. They override any session wide default configured with
+    /// [`FirestoreDb::clone_with_request_tags()`](crate::FirestoreDb::clone_with_request_tags).
+    ///
+    /// # Arguments
+    /// * `request_tags`: An iterator of tags to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request tags set.
+    #[inline]
+    pub fn request_tags<I>(self, request_tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<FirestoreRequestTag>,
+    {
+        self.request_options(FirestoreRequestOptions::from_tags(request_tags))
+    }
+
+    /// Attaches request options to this query.
+    ///
+    /// # Arguments
+    /// * `options`: The [`FirestoreRequestOptions`] to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request options set.
+    #[inline]
+    pub fn request_options(self, options: FirestoreRequestOptions) -> Self {
+        Self {
+            params: self.params.with_request_options(options),
+            ..self
+        }
+    }
+
     /// Specifies that the query results should be deserialized into a specific Rust type `T`.
     ///
     /// # Type Parameters
@@ -406,10 +443,16 @@ where
     /// A [`FirestoreDocChangesListenerInitBuilder`] to configure and start the listener.
     #[inline]
     pub fn listen(self) -> FirestoreDocChangesListenerInitBuilder<'a, D> {
-        FirestoreDocChangesListenerInitBuilder::new(
+        let request_options = self.params.request_options.clone();
+        let builder = FirestoreDocChangesListenerInitBuilder::new(
             self.db,
             FirestoreTargetType::Query(self.params),
-        )
+        );
+
+        match request_options {
+            Some(options) => builder.request_options(options),
+            None => builder,
+        }
     }
 
     /// Specifies aggregations to be performed over the documents matching this query.
@@ -507,6 +550,40 @@ where
             db,
             params,
             _pd: PhantomData,
+        }
+    }
+
+    /// Attaches request tags to this query.
+    ///
+    /// They override any session wide default configured with
+    /// [`FirestoreDb::clone_with_request_tags()`](crate::FirestoreDb::clone_with_request_tags).
+    ///
+    /// # Arguments
+    /// * `request_tags`: An iterator of tags to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request tags set.
+    #[inline]
+    pub fn request_tags<I>(self, request_tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<FirestoreRequestTag>,
+    {
+        self.request_options(FirestoreRequestOptions::from_tags(request_tags))
+    }
+
+    /// Attaches request options to this query.
+    ///
+    /// # Arguments
+    /// * `options`: The [`FirestoreRequestOptions`] to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request options set.
+    #[inline]
+    pub fn request_options(self, options: FirestoreRequestOptions) -> Self {
+        Self {
+            params: self.params.with_request_options(options),
+            ..self
         }
     }
 
@@ -1151,6 +1228,7 @@ where
     listener_params: FirestoreListenerParams,
     target_type: FirestoreTargetType,
     labels: HashMap<String, String>,
+    request_options: Option<FirestoreRequestOptions>,
 }
 
 impl<'a, D> FirestoreDocChangesListenerInitBuilder<'a, D>
@@ -1165,6 +1243,7 @@ where
             listener_params: FirestoreListenerParams::new(),
             target_type,
             labels: HashMap::new(),
+            request_options: None,
         }
     }
 
@@ -1180,6 +1259,37 @@ where
     #[inline]
     pub fn labels(self, labels: HashMap<String, String>) -> Self {
         Self { labels, ..self }
+    }
+
+    /// Attaches request tags to the listen requests of this target.
+    ///
+    /// # Arguments
+    /// * `request_tags`: An iterator of tags to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request tags set.
+    #[inline]
+    pub fn request_tags<I>(self, request_tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<FirestoreRequestTag>,
+    {
+        self.request_options(FirestoreRequestOptions::from_tags(request_tags))
+    }
+
+    /// Attaches request options to the listen requests of this target.
+    ///
+    /// # Arguments
+    /// * `options`: The [`FirestoreRequestOptions`] to attach.
+    ///
+    /// # Returns
+    /// The builder instance with the request options set.
+    #[inline]
+    pub fn request_options(self, options: FirestoreRequestOptions) -> Self {
+        Self {
+            request_options: Some(options),
+            ..self
+        }
     }
 
     /// Sets the initial delay for retrying the listener connection on failure.
@@ -1220,11 +1330,10 @@ where
     where
         S: FirestoreResumeStateStorage + Send + Sync + Clone + 'static,
     {
-        listener.add_target(FirestoreListenerTargetParams::new(
-            target,
-            self.target_type,
-            self.labels,
-        ))?;
+        listener.add_target(
+            FirestoreListenerTargetParams::new(target, self.target_type, self.labels)
+                .opt_request_options(self.request_options),
+        )?;
 
         Ok(())
     }
@@ -1373,7 +1482,7 @@ where
 mod tests {
     use crate::fluent_api::tests::*;
     use crate::fluent_api::FirestoreExprBuilder;
-    use crate::{path, paths, FirestoreQueryCollection};
+    use crate::{path, paths, FirestoreQueryCollection, FirestoreRequestOptions};
 
     #[test]
     fn select_query_builder_test_fields() {
@@ -1389,6 +1498,61 @@ mod tests {
                 path!(TestStructure::one_more_string),
                 path!(TestStructure::some_num),
             ])
+        )
+    }
+
+    #[test]
+    fn select_query_builder_request_tags() {
+        let builder = FirestoreExprBuilder::new(&mockdb::MockDatabase {})
+            .select()
+            .from("test")
+            .request_tags(["tag-1", "tag-2"]);
+
+        assert_eq!(
+            builder.params.request_options,
+            Some(FirestoreRequestOptions::from_tags(["tag-1", "tag-2"]))
+        )
+    }
+
+    #[test]
+    fn select_query_builder_request_tags_inherited_by_partition_query() {
+        let builder = FirestoreExprBuilder::new(&mockdb::MockDatabase {})
+            .select()
+            .from("test")
+            .request_tags(["tag-1"])
+            .partition_query();
+
+        assert_eq!(
+            builder.params.request_options,
+            Some(FirestoreRequestOptions::from_tags(["tag-1"]))
+        )
+    }
+
+    #[test]
+    fn select_query_builder_request_tags_forwarded_to_listener() {
+        let builder = FirestoreExprBuilder::new(&mockdb::MockDatabase {})
+            .select()
+            .from("test")
+            .request_tags(["tag-1"])
+            .listen();
+
+        assert_eq!(
+            builder.request_options,
+            Some(FirestoreRequestOptions::from_tags(["tag-1"]))
+        )
+    }
+
+    #[test]
+    fn select_batch_listen_builder_request_tags() {
+        let builder = FirestoreExprBuilder::new(&mockdb::MockDatabase {})
+            .select()
+            .by_id_in("test")
+            .batch_listen(["test-0"])
+            .request_tags(["tag-1"]);
+
+        assert_eq!(
+            builder.request_options,
+            Some(FirestoreRequestOptions::from_tags(["tag-1"]))
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //! - Transactions support;
 //! - Streaming batch writes with automatic throttling to avoid time limits from Firestore;
 //! - Aggregated Queries;
+//! - Request tags (request options) to attribute Firestore usage;
 //! - Google client based on [gcloud-sdk library](https://github.com/abdolence/gcloud-sdk-rs)
 //!   that automatically detects GKE environment or application default accounts for local development;
 //!


### PR DESCRIPTION
Adds support for the new `google.firestore.v1.RequestOptions` message and its request tags, in both the native and the fluent API.

Request tags are reported by Firestore in its monitoring and billing breakdowns, so they allow attributing reads and writes to a specific feature, tenant or background job.

This also bumps gcloud-sdk to 0.31.0, which is where `RequestOptions` was introduced. The two are inseparable: every Firestore request message gained a `request_options` field, and the requests here are built with exhaustive struct literals, so all 18 construction sites had to be updated anyway.

### API

Session wide, for every request issued through an instance. This is also how the CRUD operations are tagged:

```rust
let tagged_db = db.clone_with_request_tags(["nightly-report"]);
```

Per operation, through the fluent API:

```rust
db.fluent()
  .select()
  .from(TEST_COLLECTION_NAME)
  .request_tags(["hot-path", "tenant-42"])
  .obj::<MyTestStructure>()
  .query()
  .await?;
```

Or through the params/options structures directly, for the native API:

```rust
FirestoreQueryParams::new(collection_id.into())
    .with_request_options(FirestoreRequestOptions::from_tags(["hot-path"]))
```

A per operation value replaces the session wide default rather than merging with it.

### Notes

- `FirestoreRequestTag` is an `rvstruct` newtype, following `FirestoreListenerTarget` and `FirestoreCacheName`.
- Per operation options are available on `FirestoreQueryParams`, both listing params, `FirestoreListenerTargetParams`, `FirestoreTransactionOptions` and both batch write options. Partition and aggregated queries inherit them from the embedded `query_params`.
- The CRUD traits (`FirestoreGetByIdSupport`, `FirestoreCreateSupport`, `FirestoreUpdateSupport`, `FirestoreDeleteSupport`) keep their existing signatures and read the session wide default only, to avoid a breaking change. They can be given per call options later through sibling methods with default trait bodies, without breaking existing implementers.
- `examples/token_auth.rs` is updated for the jiff based `Token` expiry in gcloud-sdk 0.31.

### Testing

`cargo fmt --check`, `cargo clippy -- -Dwarnings`, `cargo test --lib` and `cargo test --doc` all pass. Unit tests cover the tag conversion, the session/operation precedence, and that the fluent builders propagate tags into the query, partition query and listener params.
