### PR TITLE
feat: Migrate from chrono to jiff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1" }
 tokio-stream = "0.1"
 futures = "0.3"
-chrono = { version = "0.4", features = ["serde", "clock"], default-features = false }
+jiff = { version = "0.2.35", features = ["std", "serde"], default-features = false }
 async-trait = "0.1"
 hex = "0.4"
 backoff = { version = "0.4", features = ["tokio"] }
@@ -55,7 +55,6 @@ tokio = { version = "1", features = ["full"] }
 tempfile = "3"
 approx = "0.5"
 rustls = "0.23"
-jiff = "0.2"
 
 [[example]]
 name = "caching_memory_collections"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Library provides a simple API for Google Firestore based on the official gRPC AP
 - Implements own Serde serializer to Firestore protobuf values;
 - Support for multiple database IDs
 - Supports for extended datatypes:
-    - Firestore timestamp with `#[serde(with)]` and a specialized structure
+    - Firestore timestamp with `#[serde(with)]` and a specialized structure (based on [jiff](https://github.com/BurntSushi/jiff), re-exported as `FirestoreDateTime`)
     - Lat/Lng
     - References
 - Caching support for collections and documents:
@@ -248,7 +248,7 @@ let object_stream: BoxStream<(String, Option<MyTestStructure>) > = db.fluent()
 
 ## Timestamps support
 
-By default, the types such as DateTime<Utc> serializes as a string
+By default, the types such as `FirestoreDateTime` (an alias for `jiff::Timestamp`) serializes as a string
 to Firestore (while deserialization works from Timestamps and Strings).
 
 To change this behaviour and support Firestore timestamps on database level there are two options:
@@ -259,11 +259,11 @@ To change this behaviour and support Firestore timestamps on database level ther
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct MyTestStructure {
     #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_optional_timestamp")]
-    updated_at: Option<DateTime<Utc>>,
+    updated_at: Option<FirestoreDateTime>,
 }
 ```
 
@@ -283,7 +283,7 @@ to JSON (so you can reuse the same model for JSON and Firestore).
 In your queries you need to use the wrapping class `firestore::FirestoreTimestamp`, for example:
 
 ```rust
-   q.field(path!(MyTestStructure::created_at)).less_than_or_equal(firestore::FirestoreTimestamp(Utc::now()))
+   q.field(path!(MyTestStructure::created_at)).less_than_or_equal(firestore::FirestoreTimestamp(FirestoreDateTime::now()))
 ```
 
 ## Nested collections
@@ -424,9 +424,9 @@ struct MyTestStructure {
     #[serde(alias = "_firestore_id")]
     id: Option<String>,
     #[serde(alias = "_firestore_created")]
-    created_at: Option<DateTime<Utc>>,
+    created_at: Option<FirestoreDateTime>,
     #[serde(alias = "_firestore_updated")]
-    updated_at: Option<DateTime<Utc>>,
+    updated_at: Option<FirestoreDateTime>,
     some_string: String,
     one_more_string: String,
     some_num: u64,
@@ -458,7 +458,7 @@ let object_returned = db
           ("inner_some_string", "inner-some-value".into()),
         ]),
       ),
-      ("created_at", FirestoreTimestamp(Utc::now()).into()),
+      ("created_at", FirestoreTimestamp(FirestoreDateTime::now()).into()),
     ])?
 )
 .execute()
@@ -590,7 +590,7 @@ test_null: Option<String>,
 ```rust
 #[serde(default)]
 #[serde(with = "firestore::serialize_as_null_timestamp")]
-test_null: Option<DateTime<Utc> >,
+test_null: Option<FirestoreDateTime>,
 ```
 
 ## Select aggregate functions

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Library provides a simple API for Google Firestore based on the official gRPC AP
 - Implements own Serde serializer to Firestore protobuf values;
 - Support for multiple database IDs
 - Supports for extended datatypes:
-    - Firestore timestamp with `#[serde(with)]` and a specialized structure (based on [jiff](https://github.com/BurntSushi/jiff), re-exported as `FirestoreDateTime`)
+    - Firestore timestamp with `#[serde(with)]` and a specialized structure (based on [jiff](https://github.com/BurntSushi/jiff), re-exported as `FirestoreInstant`)
     - Lat/Lng
     - References
 - Caching support for collections and documents:
@@ -248,7 +248,7 @@ let object_stream: BoxStream<(String, Option<MyTestStructure>) > = db.fluent()
 
 ## Timestamps support
 
-By default, the types such as `FirestoreDateTime` (an alias for `jiff::Timestamp`) serializes as a string
+By default, the types such as `FirestoreInstant` (an alias for `jiff::Timestamp`) serializes as a string
 to Firestore (while deserialization works from Timestamps and Strings).
 
 To change this behaviour and support Firestore timestamps on database level there are two options:
@@ -259,11 +259,11 @@ To change this behaviour and support Firestore timestamps on database level ther
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct MyTestStructure {
     #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_optional_timestamp")]
-    updated_at: Option<FirestoreDateTime>,
+    updated_at: Option<FirestoreInstant>,
 }
 ```
 
@@ -283,7 +283,7 @@ to JSON (so you can reuse the same model for JSON and Firestore).
 In your queries you need to use the wrapping class `firestore::FirestoreTimestamp`, for example:
 
 ```rust
-   q.field(path!(MyTestStructure::created_at)).less_than_or_equal(firestore::FirestoreTimestamp(FirestoreDateTime::now()))
+   q.field(path!(MyTestStructure::created_at)).less_than_or_equal(firestore::FirestoreTimestamp(FirestoreInstant::now()))
 ```
 
 ## Nested collections
@@ -424,9 +424,9 @@ struct MyTestStructure {
     #[serde(alias = "_firestore_id")]
     id: Option<String>,
     #[serde(alias = "_firestore_created")]
-    created_at: Option<FirestoreDateTime>,
+    created_at: Option<FirestoreInstant>,
     #[serde(alias = "_firestore_updated")]
-    updated_at: Option<FirestoreDateTime>,
+    updated_at: Option<FirestoreInstant>,
     some_string: String,
     one_more_string: String,
     some_num: u64,
@@ -458,7 +458,7 @@ let object_returned = db
           ("inner_some_string", "inner-some-value".into()),
         ]),
       ),
-      ("created_at", FirestoreTimestamp(FirestoreDateTime::now()).into()),
+      ("created_at", FirestoreTimestamp(FirestoreInstant::now()).into()),
     ])?
 )
 .execute()
@@ -590,7 +590,7 @@ test_null: Option<String>,
 ```rust
 #[serde(default)]
 #[serde(with = "firestore::serialize_as_null_timestamp")]
-test_null: Option<FirestoreDateTime>,
+test_null: Option<FirestoreInstant>,
 ```
 
 ## Select aggregate functions

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Library provides a simple API for Google Firestore based on the official gRPC AP
 - Implements own Serde serializer to Firestore protobuf values;
 - Support for multiple database IDs
 - Supports for extended datatypes:
-    - Firestore timestamp with `#[serde(with)]` and a specialized structure (based on [jiff](https://github.com/BurntSushi/jiff), re-exported as `FirestoreInstant`)
+    - Firestore timestamp as a `FirestoreTimestamp` type or with `#[serde(with)]` attributes (based on [jiff](https://github.com/BurntSushi/jiff))
     - Lat/Lng
     - References
 - Caching support for collections and documents:
@@ -248,12 +248,38 @@ let object_stream: BoxStream<(String, Option<MyTestStructure>) > = db.fluent()
 
 ## Timestamps support
 
-By default, the types such as `FirestoreInstant` (an alias for `jiff::Timestamp`) serializes as a string
-to Firestore (while deserialization works from Timestamps and Strings).
+By default, date/time values serialize as a string to Firestore (while
+deserialization works from Timestamps and Strings). To store them as native
+Firestore timestamps there are two options.
 
-To change this behaviour and support Firestore timestamps on database level there are two options:
+- Using the type `FirestoreTimestamp`, which needs no attributes:
 
-- `#[serde(with)]` and attributes:
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct MyTestStructure {
+    created_at: FirestoreTimestamp,
+    updated_at: Option<FirestoreTimestamp>
+}
+```
+
+It can be created with `FirestoreTimestamp::now()`, parsed from a string, and
+converted from/to `std::time::SystemTime`:
+
+```rust
+let now = FirestoreTimestamp::now();
+let from_system_time: FirestoreTimestamp = SystemTime::now().try_into()?;
+let back_to_system_time: SystemTime = now.into();
+```
+
+Use it in your queries as well, for example:
+
+```rust
+   q.field(path!(MyTestStructure::created_at)).less_than_or_equal(FirestoreTimestamp::now())
+```
+
+- Or, if you prefer to keep a plain instant in your model, use
+  `FirestoreInstant` (an alias for `jiff::Timestamp`) with `#[serde(with)]`
+  attributes:
 
 ```rust
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -267,24 +293,9 @@ struct MyTestStructure {
 }
 ```
 
-- using a type `FirestoreTimestamp`:
-
-```rust
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct MyTestStructure {
-    created_at: firestore::FirestoreTimestamp,
-    updated_at: Option<firestore::FirestoreTimestamp>
-}
-```
-
-This will change it only for firestore serialization, but it still serializes as string
-to JSON (so you can reuse the same model for JSON and Firestore).
-
-In your queries you need to use the wrapping class `firestore::FirestoreTimestamp`, for example:
-
-```rust
-   q.field(path!(MyTestStructure::created_at)).less_than_or_equal(firestore::FirestoreTimestamp(FirestoreInstant::now()))
-```
+Both change the representation only for Firestore serialization, and still
+serialize as a string to JSON, so the same model can be reused for JSON and
+Firestore.
 
 ## Nested collections
 
@@ -424,9 +435,9 @@ struct MyTestStructure {
     #[serde(alias = "_firestore_id")]
     id: Option<String>,
     #[serde(alias = "_firestore_created")]
-    created_at: Option<FirestoreInstant>,
+    created_at: Option<FirestoreTimestamp>,
     #[serde(alias = "_firestore_updated")]
-    updated_at: Option<FirestoreInstant>,
+    updated_at: Option<FirestoreTimestamp>,
     some_string: String,
     one_more_string: String,
     some_num: u64,
@@ -458,7 +469,7 @@ let object_returned = db
           ("inner_some_string", "inner-some-value".into()),
         ]),
       ),
-      ("created_at", FirestoreTimestamp(FirestoreInstant::now()).into()),
+      ("created_at", FirestoreTimestamp::now().into()),
     ])?
 )
 .execute()

--- a/examples/batch-get-stream.rs
+++ b/examples/batch-get-stream.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             some_string: "Test".to_string(),
             one_more_string: "Test2".to_string(),
             some_num: 42,
-            created_at: FirestoreDateTime::now(),
+            created_at: FirestoreInstant::now(),
         };
 
         // Remove if it already exist

--- a/examples/batch-get-stream.rs
+++ b/examples/batch-get-stream.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             some_string: "Test".to_string(),
             one_more_string: "Test2".to_string(),
             some_num: 42,
-            created_at: FirestoreInstant::now(),
+            created_at: FirestoreTimestamp::now(),
         };
 
         // Remove if it already exist

--- a/examples/batch-get-stream.rs
+++ b/examples/batch-get-stream.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
@@ -15,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -38,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             some_string: "Test".to_string(),
             one_more_string: "Test2".to_string(),
             some_num: 42,
-            created_at: Utc::now(),
+            created_at: FirestoreDateTime::now(),
         };
 
         // Remove if it already exist

--- a/examples/batch-write-simple.rs
+++ b/examples/batch-write-simple.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +9,7 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
 struct MyTestStructure {
     some_id: String,
     some_string: String,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -35,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let my_struct = MyTestStructure {
             some_id: format!("test-{idx}"),
             some_string: "Test".to_string(),
-            created_at: Utc::now(),
+            created_at: FirestoreDateTime::now(),
         };
 
         db.fluent()

--- a/examples/batch-write-simple.rs
+++ b/examples/batch-write-simple.rs
@@ -9,7 +9,7 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
 struct MyTestStructure {
     some_id: String,
     some_string: String,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let my_struct = MyTestStructure {
             some_id: format!("test-{idx}"),
             some_string: "Test".to_string(),
-            created_at: FirestoreInstant::now(),
+            created_at: FirestoreTimestamp::now(),
         };
 
         db.fluent()

--- a/examples/batch-write-simple.rs
+++ b/examples/batch-write-simple.rs
@@ -9,7 +9,7 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
 struct MyTestStructure {
     some_id: String,
     some_string: String,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let my_struct = MyTestStructure {
             some_id: format!("test-{idx}"),
             some_string: "Test".to_string(),
-            created_at: FirestoreDateTime::now(),
+            created_at: FirestoreInstant::now(),
         };
 
         db.fluent()

--- a/examples/batch-write-streaming.rs
+++ b/examples/batch-write-streaming.rs
@@ -10,7 +10,7 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
 struct MyTestStructure {
     some_id: String,
     some_string: String,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let my_struct = MyTestStructure {
             some_id: format!("test-{idx}"),
             some_string: "Test".to_string(),
-            created_at: FirestoreDateTime::now(),
+            created_at: FirestoreInstant::now(),
         };
 
         db.fluent()

--- a/examples/batch-write-streaming.rs
+++ b/examples/batch-write-streaming.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::TryStreamExt;
 use serde::{Deserialize, Serialize};
@@ -11,7 +10,7 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
 struct MyTestStructure {
     some_id: String,
     some_string: String,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -41,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let my_struct = MyTestStructure {
             some_id: format!("test-{idx}"),
             some_string: "Test".to_string(),
-            created_at: Utc::now(),
+            created_at: FirestoreDateTime::now(),
         };
 
         db.fluent()

--- a/examples/batch-write-streaming.rs
+++ b/examples/batch-write-streaming.rs
@@ -10,7 +10,7 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
 struct MyTestStructure {
     some_id: String,
     some_string: String,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let my_struct = MyTestStructure {
             some_id: format!("test-{idx}"),
             some_string: "Test".to_string(),
-            created_at: FirestoreInstant::now(),
+            created_at: FirestoreTimestamp::now(),
         };
 
         db.fluent()

--- a/examples/caching_memory_collections.rs
+++ b/examples/caching_memory_collections.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Create an instance
     let db = FirestoreDb::new(&config_env_var("PROJECT_ID")?).await?;
 
-    const TEST_COLLECTION_NAME: &'static str = "test-caching";
+    const TEST_COLLECTION_NAME: &str = "test-caching";
 
     let mut cache = FirestoreCache::new(
         "example-mem-cache".into(),

--- a/examples/caching_memory_collections.rs
+++ b/examples/caching_memory_collections.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: FirestoreDateTime::now(),
+                created_at: FirestoreInstant::now(),
             };
 
             // Let's insert some data

--- a/examples/caching_memory_collections.rs
+++ b/examples/caching_memory_collections.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
@@ -15,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -68,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: Utc::now(),
+                created_at: FirestoreDateTime::now(),
             };
 
             // Let's insert some data

--- a/examples/caching_memory_collections.rs
+++ b/examples/caching_memory_collections.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: FirestoreInstant::now(),
+                created_at: FirestoreTimestamp::now(),
             };
 
             // Let's insert some data

--- a/examples/caching_persistent_collections.rs
+++ b/examples/caching_persistent_collections.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Create an instance
     let db = FirestoreDb::new(&config_env_var("PROJECT_ID")?).await?;
 
-    const TEST_COLLECTION_NAME: &'static str = "test-caching";
+    const TEST_COLLECTION_NAME: &str = "test-caching";
 
     let mut cache = FirestoreCache::new(
         "example-persistent-cache".into(),

--- a/examples/caching_persistent_collections.rs
+++ b/examples/caching_persistent_collections.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: FirestoreDateTime::now(),
+                created_at: FirestoreInstant::now(),
             };
 
             // Let's insert some data

--- a/examples/caching_persistent_collections.rs
+++ b/examples/caching_persistent_collections.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
@@ -15,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -68,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: Utc::now(),
+                created_at: FirestoreDateTime::now(),
             };
 
             // Let's insert some data

--- a/examples/caching_persistent_collections.rs
+++ b/examples/caching_persistent_collections.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: FirestoreInstant::now(),
+                created_at: FirestoreTimestamp::now(),
             };
 
             // Let's insert some data

--- a/examples/camel-case.rs
+++ b/examples/camel-case.rs
@@ -15,7 +15,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             some_string: "Test".to_string(),
             one_more_string: "Test2".to_string(),
             some_num: 42 - i,
-            created_at: FirestoreDateTime::now(),
+            created_at: FirestoreInstant::now(),
         };
 
         // Remove if it already exist

--- a/examples/camel-case.rs
+++ b/examples/camel-case.rs
@@ -15,7 +15,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             some_string: "Test".to_string(),
             one_more_string: "Test2".to_string(),
             some_num: 42 - i,
-            created_at: FirestoreInstant::now(),
+            created_at: FirestoreTimestamp::now(),
         };
 
         // Remove if it already exist

--- a/examples/camel-case.rs
+++ b/examples/camel-case.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use futures::StreamExt;
@@ -16,7 +15,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -39,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             some_string: "Test".to_string(),
             one_more_string: "Test2".to_string(),
             some_num: 42 - i,
-            created_at: Utc::now(),
+            created_at: FirestoreDateTime::now(),
         };
 
         // Remove if it already exist

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -34,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "Test".to_string(),
         one_more_string: "Test2".to_string(),
         some_num: 41,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
     };
 
     db.fluent()

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "Test".to_string(),
         one_more_string: "Test2".to_string(),
         some_num: 41,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
     };
 
     db.fluent()

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "Test".to_string(),
         one_more_string: "Test2".to_string(),
         some_num: 41,
-        created_at: FirestoreInstant::now(),
+        created_at: FirestoreTimestamp::now(),
     };
 
     db.fluent()

--- a/examples/database_id_option.rs
+++ b/examples/database_id_option.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "Test".to_string(),
         one_more_string: "Test2".to_string(),
         some_num: 41,
-        created_at: FirestoreInstant::now(),
+        created_at: FirestoreTimestamp::now(),
     };
 
     db.fluent()

--- a/examples/database_id_option.rs
+++ b/examples/database_id_option.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -38,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "Test".to_string(),
         one_more_string: "Test2".to_string(),
         some_num: 41,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
     };
 
     db.fluent()

--- a/examples/database_id_option.rs
+++ b/examples/database_id_option.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "Test".to_string(),
         one_more_string: "Test2".to_string(),
         some_num: 41,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
     };
 
     db.fluent()

--- a/examples/dynamic_doc_level_crud.rs
+++ b/examples/dynamic_doc_level_crud.rs
@@ -43,10 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         ("inner_some_string", "inner-value".into()),
                     ]),
                 ),
-                (
-                    "created_at",
-                    FirestoreTimestamp(FirestoreInstant::now()).into(),
-                ),
+                ("created_at", FirestoreTimestamp::now().into()),
             ],
         )?)
         .execute()

--- a/examples/dynamic_doc_level_crud.rs
+++ b/examples/dynamic_doc_level_crud.rs
@@ -1,4 +1,3 @@
-use chrono::prelude::*;
 use firestore::*;
 
 pub fn config_env_var(name: &str) -> Result<String, String> {
@@ -44,7 +43,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         ("inner_some_string", "inner-value".into()),
                     ]),
                 ),
-                ("created_at", FirestoreTimestamp(Utc::now()).into()),
+                (
+                    "created_at",
+                    FirestoreTimestamp(FirestoreDateTime::now()).into(),
+                ),
             ],
         )?)
         .execute()

--- a/examples/dynamic_doc_level_crud.rs
+++ b/examples/dynamic_doc_level_crud.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 ),
                 (
                     "created_at",
-                    FirestoreTimestamp(FirestoreDateTime::now()).into(),
+                    FirestoreTimestamp(FirestoreInstant::now()).into(),
                 ),
             ],
         )?)

--- a/examples/explain-query.rs
+++ b/examples/explain-query.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: FirestoreInstant::now(),
+                created_at: FirestoreTimestamp::now(),
             };
 
             // Let's insert some data

--- a/examples/explain-query.rs
+++ b/examples/explain-query.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
@@ -15,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -49,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: Utc::now(),
+                created_at: FirestoreDateTime::now(),
             };
 
             // Let's insert some data

--- a/examples/explain-query.rs
+++ b/examples/explain-query.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: FirestoreDateTime::now(),
+                created_at: FirestoreInstant::now(),
             };
 
             // Let's insert some data

--- a/examples/generated-document-id.rs
+++ b/examples/generated-document-id.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use serde::{Deserialize, Serialize};
 
@@ -12,9 +11,9 @@ struct MyTestStructure {
     #[serde(alias = "_firestore_id")]
     id: Option<String>,
     #[serde(alias = "_firestore_created")]
-    created_at: Option<DateTime<Utc>>,
+    created_at: Option<FirestoreDateTime>,
     #[serde(alias = "_firestore_updated")]
-    updated_at: Option<DateTime<Utc>>,
+    updated_at: Option<FirestoreDateTime>,
     test: Option<String>,
     some_string: String,
     one_more_string: String,

--- a/examples/generated-document-id.rs
+++ b/examples/generated-document-id.rs
@@ -11,9 +11,9 @@ struct MyTestStructure {
     #[serde(alias = "_firestore_id")]
     id: Option<String>,
     #[serde(alias = "_firestore_created")]
-    created_at: Option<FirestoreInstant>,
+    created_at: Option<FirestoreTimestamp>,
     #[serde(alias = "_firestore_updated")]
-    updated_at: Option<FirestoreInstant>,
+    updated_at: Option<FirestoreTimestamp>,
     test: Option<String>,
     some_string: String,
     one_more_string: String,

--- a/examples/generated-document-id.rs
+++ b/examples/generated-document-id.rs
@@ -11,9 +11,9 @@ struct MyTestStructure {
     #[serde(alias = "_firestore_id")]
     id: Option<String>,
     #[serde(alias = "_firestore_created")]
-    created_at: Option<FirestoreDateTime>,
+    created_at: Option<FirestoreInstant>,
     #[serde(alias = "_firestore_updated")]
-    updated_at: Option<FirestoreDateTime>,
+    updated_at: Option<FirestoreInstant>,
     test: Option<String>,
     some_string: String,
     one_more_string: String,

--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -16,7 +16,7 @@ struct MyTestStructure {
     some_num: u64,
 
     #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 const TEST_COLLECTION_NAME: &str = "test-listen";
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_id: "test-1".to_string(),
         some_string: "test-str".to_string(),
         some_num: 42,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
     };
 
     let new_doc: MyTestStructure = db

--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -15,8 +15,7 @@ struct MyTestStructure {
     some_string: String,
     some_num: u64,
 
-    #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 const TEST_COLLECTION_NAME: &str = "test-listen";
@@ -48,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_id: "test-1".to_string(),
         some_string: "test-str".to_string(),
         some_num: 42,
-        created_at: FirestoreInstant::now(),
+        created_at: FirestoreTimestamp::now(),
     };
 
     let new_doc: MyTestStructure = db

--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -1,4 +1,3 @@
-use chrono::prelude::*;
 use firestore::*;
 use serde::{Deserialize, Serialize};
 use std::io::Read;
@@ -17,7 +16,7 @@ struct MyTestStructure {
     some_num: u64,
 
     #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 const TEST_COLLECTION_NAME: &str = "test-listen";
@@ -49,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_id: "test-1".to_string(),
         some_string: "test-str".to_string(),
         some_num: 42,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
     };
 
     let new_doc: MyTestStructure = db

--- a/examples/partition-query.rs
+++ b/examples/partition-query.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
@@ -15,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -38,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     //         some_string: "Test".to_string(),
     //         one_more_string: "Test2".to_string(),
     //         some_num: i,
-    //         created_at: Utc::now(),
+    //         created_at: FirestoreDateTime::now(),
     //     };
     //
     //     if db

--- a/examples/partition-query.rs
+++ b/examples/partition-query.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     //         some_string: "Test".to_string(),
     //         one_more_string: "Test2".to_string(),
     //         some_num: i,
-    //         created_at: FirestoreDateTime::now(),
+    //         created_at: FirestoreInstant::now(),
     //     };
     //
     //     if db

--- a/examples/partition-query.rs
+++ b/examples/partition-query.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     //         some_string: "Test".to_string(),
     //         one_more_string: "Test2".to_string(),
     //         some_num: i,
-    //         created_at: FirestoreInstant::now(),
+    //         created_at: FirestoreTimestamp::now(),
     //     };
     //
     //     if db

--- a/examples/query-with-cursor.rs
+++ b/examples/query-with-cursor.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             some_string: "Test".to_string(),
             one_more_string: "Test2".to_string(),
             some_num: 42,
-            created_at: FirestoreDateTime::now(),
+            created_at: FirestoreInstant::now(),
         };
 
         // Remove if it already exist

--- a/examples/query-with-cursor.rs
+++ b/examples/query-with-cursor.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             some_string: "Test".to_string(),
             one_more_string: "Test2".to_string(),
             some_num: 42,
-            created_at: FirestoreInstant::now(),
+            created_at: FirestoreTimestamp::now(),
         };
 
         // Remove if it already exist

--- a/examples/query-with-cursor.rs
+++ b/examples/query-with-cursor.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use futures::StreamExt;
@@ -15,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -38,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             some_string: "Test".to_string(),
             one_more_string: "Test2".to_string(),
             some_num: 42,
-            created_at: Utc::now(),
+            created_at: FirestoreDateTime::now(),
         };
 
         // Remove if it already exist

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: FirestoreInstant::now(),
+                created_at: FirestoreTimestamp::now(),
             };
 
             // Let's insert some data

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
@@ -15,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -49,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: Utc::now(),
+                created_at: FirestoreDateTime::now(),
             };
 
             // Let's insert some data

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -14,7 +14,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 some_string: "Test".to_string(),
                 one_more_string: "Test2".to_string(),
                 some_num: i,
-                created_at: FirestoreDateTime::now(),
+                created_at: FirestoreInstant::now(),
             };
 
             // Let's insert some data

--- a/examples/request-tags.rs
+++ b/examples/request-tags.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};
@@ -13,7 +12,7 @@ struct MyTestStructure {
     some_id: String,
     some_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -33,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_id: "test-1".to_string(),
         some_string: "Test".to_string(),
         some_num: 42,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
     };
 
     // Request tags are attached to every request issued through this instance.

--- a/examples/request-tags.rs
+++ b/examples/request-tags.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_id: String,
     some_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_id: "test-1".to_string(),
         some_string: "Test".to_string(),
         some_num: 42,
-        created_at: FirestoreInstant::now(),
+        created_at: FirestoreTimestamp::now(),
     };
 
     // Request tags are attached to every request issued through this instance.

--- a/examples/request-tags.rs
+++ b/examples/request-tags.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_id: String,
     some_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_id: "test-1".to_string(),
         some_string: "Test".to_string(),
         some_num: 42,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
     };
 
     // Request tags are attached to every request issued through this instance.

--- a/examples/timestamp.rs
+++ b/examples/timestamp.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     // Using a special attribute to indicate timestamp serialization for Firestore
     // (for serde_json it will be still the same, usually String serialization, so you can reuse the models)
     #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 
     // Or you can use a wrapping type
     updated_at: Option<FirestoreTimestamp>,
@@ -21,11 +21,11 @@ struct MyTestStructure {
     // Or one more attribute for optionals
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_optional_timestamp")]
-    updated_at_attr: Option<FirestoreDateTime>,
+    updated_at_attr: Option<FirestoreInstant>,
 
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_optional_timestamp")]
-    updated_at_attr_always_none: Option<FirestoreDateTime>,
+    updated_at_attr_always_none: Option<FirestoreInstant>,
 }
 
 #[tokio::main]
@@ -43,10 +43,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let my_struct = MyTestStructure {
         some_id: "test-1".to_string(),
-        created_at: FirestoreDateTime::now(),
-        updated_at: Some(FirestoreDateTime::now().into()),
+        created_at: FirestoreInstant::now(),
+        updated_at: Some(FirestoreInstant::now().into()),
         updated_at_always_none: None,
-        updated_at_attr: Some(FirestoreDateTime::now()),
+        updated_at_attr: Some(FirestoreInstant::now()),
         updated_at_attr_always_none: None,
     };
 
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             q.for_all([q
                 .field(path!(MyTestStructure::created_at))
                 .less_than_or_equal(
-                    firestore::FirestoreTimestamp(FirestoreDateTime::now()), // Using the wrapping type to indicate serialization without attribute
+                    firestore::FirestoreTimestamp(FirestoreInstant::now()), // Using the wrapping type to indicate serialization without attribute
                 )])
         })
         .obj()

--- a/examples/timestamp.rs
+++ b/examples/timestamp.rs
@@ -1,5 +1,6 @@
 use firestore::*;
 use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
 
 pub fn config_env_var(name: &str) -> Result<String, String> {
     std::env::var(name).map_err(|e| format!("{name}: {e}"))
@@ -9,16 +10,19 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct MyTestStructure {
     some_id: String,
-    // Using a special attribute to indicate timestamp serialization for Firestore
-    // (for serde_json it will be still the same, usually String serialization, so you can reuse the models)
-    #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: FirestoreInstant,
 
-    // Or you can use a wrapping type
+    // The simplest option: the wrapping type serializes as a Firestore timestamp
+    // without any attribute. For serde_json it is still a string, so the same
+    // model can be reused for both JSON and Firestore.
+    created_at: FirestoreTimestamp,
     updated_at: Option<FirestoreTimestamp>,
     updated_at_always_none: Option<FirestoreTimestamp>,
 
-    // Or one more attribute for optionals
+    // Or keep a plain instant in your model and use an attribute instead
+    #[serde(with = "firestore::serialize_as_timestamp")]
+    created_at_attr: FirestoreInstant,
+
+    // And one more attribute for optionals
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_optional_timestamp")]
     updated_at_attr: Option<FirestoreInstant>,
@@ -41,14 +45,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     const TEST_COLLECTION_NAME: &str = "test-ts1";
 
+    // Timestamps can be created from the library types, or converted from
+    // the standard `SystemTime`
+    let now_from_system_time: FirestoreTimestamp = SystemTime::now().try_into()?;
+
     let my_struct = MyTestStructure {
         some_id: "test-1".to_string(),
-        created_at: FirestoreInstant::now(),
-        updated_at: Some(FirestoreInstant::now().into()),
+        created_at: FirestoreTimestamp::now(),
+        updated_at: Some(now_from_system_time),
         updated_at_always_none: None,
+        created_at_attr: FirestoreInstant::now(),
         updated_at_attr: Some(FirestoreInstant::now()),
         updated_at_attr_always_none: None,
     };
+
+    // And converted back to a `SystemTime` when you need to hand them over to
+    // other libraries
+    let created_at_system_time: SystemTime = my_struct.created_at.into();
+    println!("Created at, as a SystemTime: {created_at_system_time:?}");
 
     db.fluent()
         .delete()
@@ -78,7 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             q.for_all([q
                 .field(path!(MyTestStructure::created_at))
                 .less_than_or_equal(
-                    firestore::FirestoreTimestamp(FirestoreInstant::now()), // Using the wrapping type to indicate serialization without attribute
+                    FirestoreTimestamp::now(), // The wrapping type works in queries as well
                 )])
         })
         .obj()

--- a/examples/timestamp.rs
+++ b/examples/timestamp.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +12,7 @@ struct MyTestStructure {
     // Using a special attribute to indicate timestamp serialization for Firestore
     // (for serde_json it will be still the same, usually String serialization, so you can reuse the models)
     #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 
     // Or you can use a wrapping type
     updated_at: Option<FirestoreTimestamp>,
@@ -22,11 +21,11 @@ struct MyTestStructure {
     // Or one more attribute for optionals
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_optional_timestamp")]
-    updated_at_attr: Option<DateTime<Utc>>,
+    updated_at_attr: Option<FirestoreDateTime>,
 
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_optional_timestamp")]
-    updated_at_attr_always_none: Option<DateTime<Utc>>,
+    updated_at_attr_always_none: Option<FirestoreDateTime>,
 }
 
 #[tokio::main]
@@ -44,10 +43,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let my_struct = MyTestStructure {
         some_id: "test-1".to_string(),
-        created_at: Utc::now(),
-        updated_at: Some(Utc::now().into()),
+        created_at: FirestoreDateTime::now(),
+        updated_at: Some(FirestoreDateTime::now().into()),
         updated_at_always_none: None,
-        updated_at_attr: Some(Utc::now()),
+        updated_at_attr: Some(FirestoreDateTime::now()),
         updated_at_attr_always_none: None,
     };
 
@@ -79,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             q.for_all([q
                 .field(path!(MyTestStructure::created_at))
                 .less_than_or_equal(
-                    firestore::FirestoreTimestamp(Utc::now()), // Using the wrapping type to indicate serialization without attribute
+                    firestore::FirestoreTimestamp(FirestoreDateTime::now()), // Using the wrapping type to indicate serialization without attribute
                 )])
         })
         .obj()

--- a/examples/token_auth.rs
+++ b/examples/token_auth.rs
@@ -15,7 +15,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 async fn my_token() -> gcloud_sdk::error::Result<gcloud_sdk::Token> {
@@ -24,7 +24,7 @@ async fn my_token() -> gcloud_sdk::error::Result<gcloud_sdk::Token> {
         config_env_var("TOKEN_VALUE")
             .expect("TOKEN_VALUE must be specified")
             .into(),
-        FirestoreDateTime::now().add(std::time::Duration::from_secs(3600)),
+        FirestoreInstant::now().add(std::time::Duration::from_secs(3600)),
     ))
 }
 

--- a/examples/token_auth.rs
+++ b/examples/token_auth.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
@@ -16,7 +15,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 async fn my_token() -> gcloud_sdk::error::Result<gcloud_sdk::Token> {
@@ -25,7 +24,7 @@ async fn my_token() -> gcloud_sdk::error::Result<gcloud_sdk::Token> {
         config_env_var("TOKEN_VALUE")
             .expect("TOKEN_VALUE must be specified")
             .into(),
-        jiff::Timestamp::now().add(std::time::Duration::from_secs(3600)),
+        FirestoreDateTime::now().add(std::time::Duration::from_secs(3600)),
     ))
 }
 

--- a/examples/token_auth.rs
+++ b/examples/token_auth.rs
@@ -15,7 +15,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 async fn my_token() -> gcloud_sdk::error::Result<gcloud_sdk::Token> {

--- a/examples/update-precondition.rs
+++ b/examples/update-precondition.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::main]
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "Test".to_string(),
         one_more_string: "Test2".to_string(),
         some_num: 41,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
     };
 
     let object_updated: MyTestStructure = db

--- a/examples/update-precondition.rs
+++ b/examples/update-precondition.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use firestore::*;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::main]
@@ -34,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "Test".to_string(),
         one_more_string: "Test2".to_string(),
         some_num: 41,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
     };
 
     let object_updated: MyTestStructure = db

--- a/examples/update-precondition.rs
+++ b/examples/update-precondition.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::main]
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "Test".to_string(),
         one_more_string: "Test2".to_string(),
         some_num: 41,
-        created_at: FirestoreInstant::now(),
+        created_at: FirestoreTimestamp::now(),
     };
 
     let object_updated: MyTestStructure = db

--- a/src/cache/backends/memory_backend.rs
+++ b/src/cache/backends/memory_backend.rs
@@ -1,5 +1,5 @@
 use crate::errors::*;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::*;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
@@ -143,7 +143,7 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
         _options: &FirestoreCacheOptions,
         db: &FirestoreDb,
     ) -> Result<Vec<FirestoreListenerTargetParams>, FirestoreError> {
-        let read_from_time = FirestoreDateTime::now();
+        let read_from_time = FirestoreInstant::now();
 
         self.preload_collections(db).await?;
 

--- a/src/cache/backends/memory_backend.rs
+++ b/src/cache/backends/memory_backend.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
+use crate::FirestoreDateTime;
 use crate::*;
 use async_trait::async_trait;
-use chrono::Utc;
 use futures::stream::BoxStream;
 use moka::future::{Cache, CacheBuilder};
 
@@ -143,7 +143,7 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
         _options: &FirestoreCacheOptions,
         db: &FirestoreDb,
     ) -> Result<Vec<FirestoreListenerTargetParams>, FirestoreError> {
-        let read_from_time = Utc::now();
+        let read_from_time = FirestoreDateTime::now();
 
         self.preload_collections(db).await?;
 

--- a/src/cache/backends/persistent_backend.rs
+++ b/src/cache/backends/persistent_backend.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 
 use crate::cache::cache_query_engine::FirestoreCacheQueryEngine;
-use chrono::Utc;
+use crate::FirestoreDateTime;
 use futures::StreamExt;
 use gcloud_sdk::google::firestore::v1::Document;
 use gcloud_sdk::prost::Message;
@@ -246,7 +246,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
         _options: &FirestoreCacheOptions,
         db: &FirestoreDb,
     ) -> Result<Vec<FirestoreListenerTargetParams>, FirestoreError> {
-        let read_from_time = Utc::now();
+        let read_from_time = FirestoreDateTime::now();
 
         self.preload_collections(db).await?;
 

--- a/src/cache/backends/persistent_backend.rs
+++ b/src/cache/backends/persistent_backend.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 
 use crate::cache::cache_query_engine::FirestoreCacheQueryEngine;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use futures::StreamExt;
 use gcloud_sdk::google::firestore::v1::Document;
 use gcloud_sdk::prost::Message;
@@ -246,7 +246,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
         _options: &FirestoreCacheOptions,
         db: &FirestoreDb,
     ) -> Result<Vec<FirestoreListenerTargetParams>, FirestoreError> {
-        let read_from_time = FirestoreDateTime::now();
+        let read_from_time = FirestoreInstant::now();
 
         self.preload_collections(db).await?;
 

--- a/src/db/aggregated_query.rs
+++ b/src/db/aggregated_query.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::derive_partial_eq_without_eq)] // Since we may not be able to implement Eq for the changes coming from Firestore protos
 
+use crate::FirestoreDateTime;
 use crate::{FirestoreDb, FirestoreError, FirestoreQueryParams, FirestoreResult};
 use async_trait::async_trait;
-use chrono::prelude::*;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::FutureExt;
@@ -307,7 +307,7 @@ impl FirestoreDb {
     ) -> BoxFuture<'a, FirestoreResult<BoxStream<'b, FirestoreResult<Option<Document>>>>> {
         async move {
             let query_request = self.create_aggregated_query_request(params.clone())?;
-            let begin_query_utc: DateTime<Utc> = Utc::now();
+            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
 
             match self
                 .client()
@@ -323,17 +323,17 @@ impl FirestoreDb {
                         .map_err(|e| e.into())
                         .boxed();
 
-                    let end_query_utc: DateTime<Utc> = Utc::now();
-                    let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let query_duration = end_query_utc.duration_since(begin_query_utc);
 
                     span.record(
                         "/firestore/response_time",
-                        query_duration.num_milliseconds(),
+                        query_duration.as_millis(),
                     );
                     span.in_scope(|| {
                         debug!(
                             collection_id = ?params.query_params.collection_id,
-                            duration_milliseconds = query_duration.num_milliseconds(),
+                            duration_milliseconds = query_duration.as_millis(),
                             "Querying stream of documents in specified collection.",
                         );
                     });
@@ -375,7 +375,7 @@ impl FirestoreDb {
     ) -> BoxFuture<'a, FirestoreResult<Vec<Document>>> {
         async move {
             let query_request = self.create_aggregated_query_request(params.clone())?;
-            let begin_query_utc: DateTime<Utc> = Utc::now();
+            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
 
             match self
                 .client()
@@ -393,17 +393,17 @@ impl FirestoreDb {
                         .into_iter()
                         .flatten()
                         .collect();
-                    let end_query_utc: DateTime<Utc> = Utc::now();
-                    let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let query_duration = end_query_utc.duration_since(begin_query_utc);
 
                     span.record(
                         "/firestore/response_time",
-                        query_duration.num_milliseconds(),
+                        query_duration.as_millis(),
                     );
                     span.in_scope(|| {
                         debug!(
                             collection_id = ?params.query_params.collection_id,
-                            duration_milliseconds = query_duration.num_milliseconds(),
+                            duration_milliseconds = query_duration.as_millis(),
                             "Querying documents in specified collection.",
                         );
                     });

--- a/src/db/aggregated_query.rs
+++ b/src/db/aggregated_query.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::derive_partial_eq_without_eq)] // Since we may not be able to implement Eq for the changes coming from Firestore protos
 
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::{FirestoreDb, FirestoreError, FirestoreQueryParams, FirestoreResult};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
@@ -307,7 +307,7 @@ impl FirestoreDb {
     ) -> BoxFuture<'a, FirestoreResult<BoxStream<'b, FirestoreResult<Option<Document>>>>> {
         async move {
             let query_request = self.create_aggregated_query_request(params.clone())?;
-            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
 
             match self
                 .client()
@@ -323,7 +323,7 @@ impl FirestoreDb {
                         .map_err(|e| e.into())
                         .boxed();
 
-                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let end_query_utc: FirestoreInstant = FirestoreInstant::now();
                     let query_duration = end_query_utc.duration_since(begin_query_utc);
 
                     span.record(
@@ -375,7 +375,7 @@ impl FirestoreDb {
     ) -> BoxFuture<'a, FirestoreResult<Vec<Document>>> {
         async move {
             let query_request = self.create_aggregated_query_request(params.clone())?;
-            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
 
             match self
                 .client()
@@ -393,7 +393,7 @@ impl FirestoreDb {
                         .into_iter()
                         .flatten()
                         .collect();
-                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let end_query_utc: FirestoreInstant = FirestoreInstant::now();
                     let query_duration = end_query_utc.duration_since(begin_query_utc);
 
                     span.record(

--- a/src/db/batch_simple_writer.rs
+++ b/src/db/batch_simple_writer.rs
@@ -1,4 +1,5 @@
 use crate::errors::*;
+use crate::FirestoreDuration;
 use crate::{
     FirestoreBatch, FirestoreBatchWriteResponse, FirestoreBatchWriter, FirestoreDb,
     FirestoreRequestOptions, FirestoreResult, FirestoreWriteResult,
@@ -12,7 +13,7 @@ use tracing::*;
 
 #[derive(Debug, Eq, PartialEq, Clone, Builder)]
 pub struct FirestoreSimpleBatchWriteOptions {
-    retry_max_elapsed_time: Option<chrono::Duration>,
+    retry_max_elapsed_time: Option<FirestoreDuration>,
 
     /// Request options (e.g. request tags) for the batch write requests.
     pub request_options: Option<FirestoreRequestOptions>,
@@ -52,7 +53,7 @@ impl FirestoreBatchWriter for FirestoreSimpleBatchWriter {
             .with_max_elapsed_time(
                 self.options
                     .retry_max_elapsed_time
-                    .map(|v| v.to_std())
+                    .map(std::time::Duration::try_from)
                     .transpose()?,
             )
             .build();

--- a/src/db/batch_writer.rs
+++ b/src/db/batch_writer.rs
@@ -1,7 +1,7 @@
 use crate::db::transaction_ops::{TransformObjectOperation, UpdateObjectOperation};
 use crate::db::DeleteOperation;
 use crate::errors::FirestoreError;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::{
     FirestoreDb, FirestoreFieldTransform, FirestoreResult, FirestoreWritePrecondition,
     FirestoreWriteResult,
@@ -24,7 +24,7 @@ pub struct FirestoreBatchWriteResponse {
     pub position: u64,
     pub write_results: Vec<FirestoreWriteResult>,
     pub statuses: Vec<Status>,
-    pub commit_time: Option<FirestoreDateTime>,
+    pub commit_time: Option<FirestoreInstant>,
 }
 
 pub struct FirestoreBatch<'a, W>

--- a/src/db/batch_writer.rs
+++ b/src/db/batch_writer.rs
@@ -1,12 +1,12 @@
 use crate::db::transaction_ops::{TransformObjectOperation, UpdateObjectOperation};
 use crate::db::DeleteOperation;
 use crate::errors::FirestoreError;
+use crate::FirestoreDateTime;
 use crate::{
     FirestoreDb, FirestoreFieldTransform, FirestoreResult, FirestoreWritePrecondition,
     FirestoreWriteResult,
 };
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use gcloud_sdk::google::firestore::v1::Write;
 use gcloud_sdk::google::rpc::Status;
 use rsb_derive::*;
@@ -24,7 +24,7 @@ pub struct FirestoreBatchWriteResponse {
     pub position: u64,
     pub write_results: Vec<FirestoreWriteResult>,
     pub statuses: Vec<Status>,
-    pub commit_time: Option<DateTime<Utc>>,
+    pub commit_time: Option<FirestoreDateTime>,
 }
 
 pub struct FirestoreBatch<'a, W>

--- a/src/db/consistency_selector.rs
+++ b/src/db/consistency_selector.rs
@@ -1,6 +1,6 @@
 use crate::errors::*;
 use crate::timestamp_utils::to_timestamp;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::{FirestoreError, FirestoreTransactionId};
 
 /// Specifies the consistency guarantee for Firestore read operations.
@@ -29,7 +29,7 @@ pub enum FirestoreConsistencySelector {
     /// data or ensuring that a sequence of reads sees a consistent snapshot without
     /// the overhead of a full transaction. The timestamp must not be older than
     /// one hour, with some exceptions for Point-in-Time Recovery enabled databases.
-    ReadTime(FirestoreDateTime),
+    ReadTime(FirestoreInstant),
 }
 
 impl TryFrom<&FirestoreConsistencySelector>

--- a/src/db/consistency_selector.rs
+++ b/src/db/consistency_selector.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
 use crate::timestamp_utils::to_timestamp;
+use crate::FirestoreDateTime;
 use crate::{FirestoreError, FirestoreTransactionId};
-use chrono::prelude::*;
 
 /// Specifies the consistency guarantee for Firestore read operations.
 ///
@@ -29,7 +29,7 @@ pub enum FirestoreConsistencySelector {
     /// data or ensuring that a sequence of reads sees a consistent snapshot without
     /// the overhead of a full transaction. The timestamp must not be older than
     /// one hour, with some exceptions for Point-in-Time Recovery enabled databases.
-    ReadTime(DateTime<Utc>),
+    ReadTime(FirestoreDateTime),
 }
 
 impl TryFrom<&FirestoreConsistencySelector>

--- a/src/db/create.rs
+++ b/src/db/create.rs
@@ -1,4 +1,4 @@
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::{FirestoreDb, FirestoreResult};
 use async_trait::async_trait;
 use gcloud_sdk::google::firestore::v1::*;
@@ -109,7 +109,7 @@ impl FirestoreCreateSupport for FirestoreDb {
             request_options: self.resolve_request_options(None),
         });
 
-        let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+        let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
 
         let create_response = self
             .client()
@@ -117,7 +117,7 @@ impl FirestoreCreateSupport for FirestoreDb {
             .create_document(create_document_request)
             .await?;
 
-        let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+        let end_query_utc: FirestoreInstant = FirestoreInstant::now();
         let query_duration = end_query_utc.duration_since(begin_query_utc);
 
         span.record("/firestore/response_time", query_duration.as_millis());

--- a/src/db/create.rs
+++ b/src/db/create.rs
@@ -1,6 +1,6 @@
+use crate::FirestoreDateTime;
 use crate::{FirestoreDb, FirestoreResult};
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use gcloud_sdk::google::firestore::v1::*;
 use serde::{Deserialize, Serialize};
 use tracing::*;
@@ -109,7 +109,7 @@ impl FirestoreCreateSupport for FirestoreDb {
             request_options: self.resolve_request_options(None),
         });
 
-        let begin_query_utc: DateTime<Utc> = Utc::now();
+        let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
 
         let create_response = self
             .client()
@@ -117,13 +117,10 @@ impl FirestoreCreateSupport for FirestoreDb {
             .create_document(create_document_request)
             .await?;
 
-        let end_query_utc: DateTime<Utc> = Utc::now();
-        let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+        let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+        let query_duration = end_query_utc.duration_since(begin_query_utc);
 
-        span.record(
-            "/firestore/response_time",
-            query_duration.num_milliseconds(),
-        );
+        span.record("/firestore/response_time", query_duration.as_millis());
 
         let response_inner = create_response.into_inner();
 

--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -1,7 +1,7 @@
 use crate::db::safe_document_path;
+use crate::FirestoreDateTime;
 use crate::{FirestoreDb, FirestoreResult, FirestoreWritePrecondition};
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use gcloud_sdk::google::firestore::v1::*;
 use tracing::*;
 
@@ -73,15 +73,12 @@ impl FirestoreDeleteSupport for FirestoreDb {
             request_options: self.resolve_request_options(None),
         });
 
-        let begin_query_utc: DateTime<Utc> = Utc::now();
+        let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
         self.client().get().delete_document(request).await?;
-        let end_query_utc: DateTime<Utc> = Utc::now();
-        let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+        let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+        let query_duration = end_query_utc.duration_since(begin_query_utc);
 
-        span.record(
-            "/firestore/response_time",
-            query_duration.num_milliseconds(),
-        );
+        span.record("/firestore/response_time", query_duration.as_millis());
 
         span.in_scope(|| {
             debug!(

--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -1,5 +1,5 @@
 use crate::db::safe_document_path;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::{FirestoreDb, FirestoreResult, FirestoreWritePrecondition};
 use async_trait::async_trait;
 use gcloud_sdk::google::firestore::v1::*;
@@ -73,9 +73,9 @@ impl FirestoreDeleteSupport for FirestoreDb {
             request_options: self.resolve_request_options(None),
         });
 
-        let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+        let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
         self.client().get().delete_document(request).await?;
-        let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+        let end_query_utc: FirestoreInstant = FirestoreInstant::now();
         let query_duration = end_query_utc.duration_since(begin_query_utc);
 
         span.record("/firestore/response_time", query_duration.as_millis());

--- a/src/db/get.rs
+++ b/src/db/get.rs
@@ -1,8 +1,8 @@
 use crate::db::safe_document_path;
 use crate::errors::*;
+use crate::FirestoreDateTime;
 use crate::*;
 use async_trait::async_trait;
-use chrono::prelude::*;
 use futures::future::{BoxFuture, FutureExt};
 use futures::stream::BoxStream;
 use futures::TryFutureExt;
@@ -578,7 +578,7 @@ impl FirestoreDb {
                 "/firestore/response_time" = field::Empty,
                 "/firestore/document_name" = document_path.as_str()
             );
-            let begin_query_utc: DateTime<Utc> = Utc::now();
+            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
 
             let request = gcloud_sdk::tonic::Request::new(GetDocumentRequest {
                 name: document_path.clone(),
@@ -603,12 +603,12 @@ impl FirestoreDb {
                 .map_err(|e| e.into())
                 .await;
 
-            let end_query_utc: DateTime<Utc> = Utc::now();
-            let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+            let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let query_duration = end_query_utc.duration_since(begin_query_utc);
 
             span.record(
                 "/firestore/response_time",
-                query_duration.num_milliseconds(),
+                query_duration.as_millis(),
             );
 
             match response {
@@ -616,7 +616,7 @@ impl FirestoreDb {
                     span.in_scope(|| {
                         debug!(
                             document_path,
-                            duration_milliseconds = query_duration.num_milliseconds(),
+                            duration_milliseconds = query_duration.as_millis(),
                             "Read document.",
                         );
                     });
@@ -759,18 +759,18 @@ impl FirestoreDb {
         if let FirestoreDbSessionCacheMode::ReadThroughCache(ref cache)
         | FirestoreDbSessionCacheMode::ReadCachedOnly(ref cache) = self.session_params.cache_mode
         {
-            let begin_query_utc: DateTime<Utc> = Utc::now();
+            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
 
             let cache_response = cache.get_doc_by_path(document_path).await?;
 
-            let end_query_utc: DateTime<Utc> = Utc::now();
-            let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+            let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let query_duration = end_query_utc.duration_since(begin_query_utc);
 
             let span = span!(
                 Level::DEBUG,
                 "Firestore Get Cache",
                 "/firestore/collection_name" = collection_id,
-                "/firestore/response_time" = query_duration.num_milliseconds(),
+                "/firestore/response_time" = query_duration.as_millis(),
                 "/firestore/document_name" = document_path,
                 "/firestore/cache_result" = field::Empty,
             );
@@ -780,7 +780,7 @@ impl FirestoreDb {
                 span.in_scope(|| {
                     debug!(
                         document_path,
-                        duration_milliseconds = query_duration.num_milliseconds(),
+                        duration_milliseconds = query_duration.as_millis(),
                         "Read document from cache.",
                     );
                 });
@@ -828,7 +828,7 @@ impl FirestoreDb {
                 "/firestore/response_time" = field::Empty
             );
 
-            let begin_query_utc: DateTime<Utc> = Utc::now();
+            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
 
             let cached_stream: BoxStream<FirestoreResult<(String, Option<FirestoreDocument>)>> =
                 cache.get_docs_by_paths(full_doc_ids).await?;
@@ -836,13 +836,10 @@ impl FirestoreDb {
             let cached_vec: Vec<(String, Option<FirestoreDocument>)> =
                 cached_stream.try_collect::<Vec<_>>().await?;
 
-            let end_query_utc: DateTime<Utc> = Utc::now();
-            let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+            let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let query_duration = end_query_utc.duration_since(begin_query_utc);
 
-            span.record(
-                "/firestore/response_time",
-                query_duration.num_milliseconds(),
-            );
+            span.record("/firestore/response_time", query_duration.as_millis());
 
             if cached_vec.len() == full_doc_ids.len()
                 || matches!(

--- a/src/db/get.rs
+++ b/src/db/get.rs
@@ -1,6 +1,6 @@
 use crate::db::safe_document_path;
 use crate::errors::*;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::*;
 use async_trait::async_trait;
 use futures::future::{BoxFuture, FutureExt};
@@ -578,7 +578,7 @@ impl FirestoreDb {
                 "/firestore/response_time" = field::Empty,
                 "/firestore/document_name" = document_path.as_str()
             );
-            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
 
             let request = gcloud_sdk::tonic::Request::new(GetDocumentRequest {
                 name: document_path.clone(),
@@ -603,7 +603,7 @@ impl FirestoreDb {
                 .map_err(|e| e.into())
                 .await;
 
-            let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let end_query_utc: FirestoreInstant = FirestoreInstant::now();
             let query_duration = end_query_utc.duration_since(begin_query_utc);
 
             span.record(
@@ -759,11 +759,11 @@ impl FirestoreDb {
         if let FirestoreDbSessionCacheMode::ReadThroughCache(ref cache)
         | FirestoreDbSessionCacheMode::ReadCachedOnly(ref cache) = self.session_params.cache_mode
         {
-            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
 
             let cache_response = cache.get_doc_by_path(document_path).await?;
 
-            let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let end_query_utc: FirestoreInstant = FirestoreInstant::now();
             let query_duration = end_query_utc.duration_since(begin_query_utc);
 
             let span = span!(
@@ -828,7 +828,7 @@ impl FirestoreDb {
                 "/firestore/response_time" = field::Empty
             );
 
-            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
 
             let cached_stream: BoxStream<FirestoreResult<(String, Option<FirestoreDocument>)>> =
                 cache.get_docs_by_paths(full_doc_ids).await?;
@@ -836,7 +836,7 @@ impl FirestoreDb {
             let cached_vec: Vec<(String, Option<FirestoreDocument>)> =
                 cached_stream.try_collect::<Vec<_>>().await?;
 
-            let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let end_query_utc: FirestoreInstant = FirestoreInstant::now();
             let query_duration = end_query_utc.duration_since(begin_query_utc);
 
             span.record("/firestore/response_time", query_duration.as_millis());

--- a/src/db/list.rs
+++ b/src/db/list.rs
@@ -1,7 +1,7 @@
 use crate::db::FirestoreDbInner;
+use crate::FirestoreDateTime;
 use crate::*;
 use async_trait::async_trait;
-use chrono::prelude::*;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::FutureExt;
@@ -320,7 +320,7 @@ impl FirestoreDb {
         span: Span,
     ) -> BoxFuture<'b, FirestoreResult<FirestoreListDocResult>> {
         async move {
-            let begin_utc: DateTime<Utc> = Utc::now();
+            let begin_utc: FirestoreDateTime = FirestoreDateTime::now();
 
             match db_inner.client.get()
                 .list_documents(
@@ -338,17 +338,17 @@ impl FirestoreDb {
                             None
                         },
                     );
-                    let end_query_utc: DateTime<Utc> = Utc::now();
-                    let listing_duration = end_query_utc.signed_duration_since(begin_utc);
+                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let listing_duration = end_query_utc.duration_since(begin_utc);
 
                     span.record(
                         "/firestore/response_time",
-                        listing_duration.num_milliseconds(),
+                        listing_duration.as_millis(),
                     );
                     span.in_scope(|| {
                         debug!(
                             collection_id = list_request.collection_id.as_str(),
-                            duration_milliseconds = listing_duration.num_milliseconds(),
+                            duration_milliseconds = listing_duration.as_millis(),
                             num_documents = result.documents.len(),
                             "Listed documents.",
                         );
@@ -485,7 +485,7 @@ impl FirestoreDb {
     ) -> BoxFuture<'a, FirestoreResult<FirestoreListCollectionIdsResult>> {
         async move {
             let list_request = self.create_list_collection_ids_request(&params)?;
-            let begin_utc: DateTime<Utc> = Utc::now();
+            let begin_utc: FirestoreDateTime = FirestoreDateTime::now();
 
             match self
                 .client()
@@ -502,16 +502,16 @@ impl FirestoreDb {
                         } else {
                             None
                         });
-                    let end_query_utc: DateTime<Utc> = Utc::now();
-                    let listing_duration = end_query_utc.signed_duration_since(begin_utc);
+                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let listing_duration = end_query_utc.duration_since(begin_utc);
 
                     span.record(
                         "/firestore/response_time",
-                        listing_duration.num_milliseconds(),
+                        listing_duration.as_millis(),
                     );
                     span.in_scope(|| {
                         debug!(
-                            duration_milliseconds = listing_duration.num_milliseconds(),
+                            duration_milliseconds = listing_duration.as_millis(),
                             "Listed collections.",
                         );
                     });
@@ -563,7 +563,7 @@ impl FirestoreDb {
                 "/firestore/response_time" = field::Empty
             );
 
-            let begin_query_utc: DateTime<Utc> = Utc::now();
+            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
 
             let collection_path = if let Some(parent) = params.parent.as_ref() {
                 format!("{}/{}", parent, params.collection_id.as_str())
@@ -577,13 +577,10 @@ impl FirestoreDb {
 
             let cached_result = cache.list_all_docs(&collection_path).await?;
 
-            let end_query_utc: DateTime<Utc> = Utc::now();
-            let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+            let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let query_duration = end_query_utc.duration_since(begin_query_utc);
 
-            span.record(
-                "/firestore/response_time",
-                query_duration.num_milliseconds(),
-            );
+            span.record("/firestore/response_time", query_duration.as_millis());
 
             match cached_result {
                 FirestoreCachedValue::UseCached(stream) => {

--- a/src/db/list.rs
+++ b/src/db/list.rs
@@ -1,5 +1,5 @@
 use crate::db::FirestoreDbInner;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::*;
 use async_trait::async_trait;
 use futures::future::BoxFuture;
@@ -320,7 +320,7 @@ impl FirestoreDb {
         span: Span,
     ) -> BoxFuture<'b, FirestoreResult<FirestoreListDocResult>> {
         async move {
-            let begin_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let begin_utc: FirestoreInstant = FirestoreInstant::now();
 
             match db_inner.client.get()
                 .list_documents(
@@ -338,7 +338,7 @@ impl FirestoreDb {
                             None
                         },
                     );
-                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let end_query_utc: FirestoreInstant = FirestoreInstant::now();
                     let listing_duration = end_query_utc.duration_since(begin_utc);
 
                     span.record(
@@ -485,7 +485,7 @@ impl FirestoreDb {
     ) -> BoxFuture<'a, FirestoreResult<FirestoreListCollectionIdsResult>> {
         async move {
             let list_request = self.create_list_collection_ids_request(&params)?;
-            let begin_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let begin_utc: FirestoreInstant = FirestoreInstant::now();
 
             match self
                 .client()
@@ -502,7 +502,7 @@ impl FirestoreDb {
                         } else {
                             None
                         });
-                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let end_query_utc: FirestoreInstant = FirestoreInstant::now();
                     let listing_duration = end_query_utc.duration_since(begin_utc);
 
                     span.record(
@@ -563,7 +563,7 @@ impl FirestoreDb {
                 "/firestore/response_time" = field::Empty
             );
 
-            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
 
             let collection_path = if let Some(parent) = params.parent.as_ref() {
                 format!("{}/{}", parent, params.collection_id.as_str())
@@ -577,7 +577,7 @@ impl FirestoreDb {
 
             let cached_result = cache.list_all_docs(&collection_path).await?;
 
-            let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let end_query_utc: FirestoreInstant = FirestoreInstant::now();
             let query_duration = end_query_utc.duration_since(begin_query_utc);
 
             span.record("/firestore/response_time", query_duration.as_millis());

--- a/src/db/listen_changes.rs
+++ b/src/db/listen_changes.rs
@@ -1,12 +1,12 @@
 use crate::db::safe_document_path;
 use crate::errors::*;
 use crate::timestamp_utils::to_timestamp;
+use crate::FirestoreDateTime;
 use crate::{
     FirestoreDb, FirestoreQueryParams, FirestoreRequestOptions, FirestoreResult,
     FirestoreResumeStateStorage,
 };
 pub use async_trait::async_trait;
-use chrono::prelude::*;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use futures::TryFutureExt;
@@ -58,7 +58,7 @@ pub enum FirestoreTargetType {
 #[derive(Debug, Clone)]
 pub enum FirestoreListenerTargetResumeType {
     Token(FirestoreListenerToken),
-    ReadTime(DateTime<Utc>),
+    ReadTime(FirestoreDateTime),
 }
 
 #[async_trait]

--- a/src/db/listen_changes.rs
+++ b/src/db/listen_changes.rs
@@ -1,7 +1,7 @@
 use crate::db::safe_document_path;
 use crate::errors::*;
 use crate::timestamp_utils::to_timestamp;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::{
     FirestoreDb, FirestoreQueryParams, FirestoreRequestOptions, FirestoreResult,
     FirestoreResumeStateStorage,
@@ -58,7 +58,7 @@ pub enum FirestoreTargetType {
 #[derive(Debug, Clone)]
 pub enum FirestoreListenerTargetResumeType {
     Token(FirestoreListenerToken),
-    ReadTime(FirestoreDateTime),
+    ReadTime(FirestoreInstant),
 }
 
 #[async_trait]

--- a/src/db/precondition_models.rs
+++ b/src/db/precondition_models.rs
@@ -1,6 +1,6 @@
 use crate::errors::FirestoreError;
 use crate::timestamp_utils::to_timestamp;
-use chrono::prelude::*;
+use crate::FirestoreDateTime;
 use gcloud_sdk::google::firestore::v1::Precondition;
 
 /// A precondition on a document, used for conditional write operations in Firestore.
@@ -23,9 +23,9 @@ pub enum FirestoreWritePrecondition {
     ///
     /// This is used for optimistic concurrency control. The operation will only succeed
     /// if the document has not been modified since the specified `update_time`.
-    /// The `DateTime<Utc>` must be microsecond-aligned, as Firestore timestamps have
+    /// The `Timestamp` must be microsecond-aligned, as Firestore timestamps have
     /// microsecond precision.
-    UpdateTime(DateTime<Utc>),
+    UpdateTime(FirestoreDateTime),
 }
 
 impl TryInto<gcloud_sdk::google::firestore::v1::Precondition> for FirestoreWritePrecondition {

--- a/src/db/precondition_models.rs
+++ b/src/db/precondition_models.rs
@@ -1,6 +1,6 @@
 use crate::errors::FirestoreError;
 use crate::timestamp_utils::to_timestamp;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use gcloud_sdk::google::firestore::v1::Precondition;
 
 /// A precondition on a document, used for conditional write operations in Firestore.
@@ -25,7 +25,7 @@ pub enum FirestoreWritePrecondition {
     /// if the document has not been modified since the specified `update_time`.
     /// The `Timestamp` must be microsecond-aligned, as Firestore timestamps have
     /// microsecond precision.
-    UpdateTime(FirestoreDateTime),
+    UpdateTime(FirestoreInstant),
 }
 
 impl TryInto<gcloud_sdk::google::firestore::v1::Precondition> for FirestoreWritePrecondition {

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -1,4 +1,4 @@
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::*;
 use async_trait::async_trait;
 use futures::future::BoxFuture;
@@ -122,7 +122,7 @@ impl FirestoreDb {
     > {
         async move {
             let query_request = self.create_query_request(params.clone())?;
-            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+            let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
 
             match self
                 .client()
@@ -138,7 +138,7 @@ impl FirestoreDb {
                         .map(|r| r.and_then(|r| r.try_into()))
                         .boxed();
 
-                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let end_query_utc: FirestoreInstant = FirestoreInstant::now();
                     let query_duration = end_query_utc.duration_since(begin_query_utc);
 
                     span.record("/firestore/response_time", query_duration.as_millis());
@@ -200,7 +200,7 @@ impl FirestoreDb {
                         "/firestore/response_time" = field::Empty
                     );
 
-                    let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
 
                     let collection_path = if let Some(parent) = params.parent.as_ref() {
                         format!("{}/{}", parent, collection_id)
@@ -210,7 +210,7 @@ impl FirestoreDb {
 
                     let result = cache.query_docs(&collection_path, params).await?;
 
-                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let end_query_utc: FirestoreInstant = FirestoreInstant::now();
                     let query_duration = end_query_utc.duration_since(begin_query_utc);
 
                     span.record("/firestore/response_time", query_duration.as_millis());

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -1,6 +1,6 @@
+use crate::FirestoreDateTime;
 use crate::*;
 use async_trait::async_trait;
-use chrono::prelude::*;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::FutureExt;
@@ -122,7 +122,7 @@ impl FirestoreDb {
     > {
         async move {
             let query_request = self.create_query_request(params.clone())?;
-            let begin_query_utc: DateTime<Utc> = Utc::now();
+            let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
 
             match self
                 .client()
@@ -138,17 +138,14 @@ impl FirestoreDb {
                         .map(|r| r.and_then(|r| r.try_into()))
                         .boxed();
 
-                    let end_query_utc: DateTime<Utc> = Utc::now();
-                    let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let query_duration = end_query_utc.duration_since(begin_query_utc);
 
-                    span.record(
-                        "/firestore/response_time",
-                        query_duration.num_milliseconds(),
-                    );
+                    span.record("/firestore/response_time", query_duration.as_millis());
                     span.in_scope(|| {
                         debug!(
                             collection_id = ?params.collection_id,
-                            duration_milliseconds = query_duration.num_milliseconds(),
+                            duration_milliseconds = query_duration.as_millis(),
                             "Queried stream of documents.",
                         );
                     });
@@ -203,7 +200,7 @@ impl FirestoreDb {
                         "/firestore/response_time" = field::Empty
                     );
 
-                    let begin_query_utc: DateTime<Utc> = Utc::now();
+                    let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
 
                     let collection_path = if let Some(parent) = params.parent.as_ref() {
                         format!("{}/{}", parent, collection_id)
@@ -213,13 +210,10 @@ impl FirestoreDb {
 
                     let result = cache.query_docs(&collection_path, params).await?;
 
-                    let end_query_utc: DateTime<Utc> = Utc::now();
-                    let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+                    let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+                    let query_duration = end_query_utc.duration_since(begin_query_utc);
 
-                    span.record(
-                        "/firestore/response_time",
-                        query_duration.num_milliseconds(),
-                    );
+                    span.record("/firestore/response_time", query_duration.as_millis());
 
                     match result {
                         FirestoreCachedValue::UseCached(stream) => {

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -182,7 +182,7 @@ impl<'a> FirestoreTransaction<'a> {
         if let Some(ref commit_time) = result.commit_time {
             self.data
                 .transaction_span
-                .record("/firestore/commit_time", commit_time.to_rfc3339());
+                .record("/firestore/commit_time", commit_time.to_string());
         }
 
         self.data.transaction_span.in_scope(|| {
@@ -369,7 +369,7 @@ impl FirestoreDb {
                 options
                     .max_elapsed_time
                     // Convert to a std `Duration` and clamp any negative durations
-                    .map(|v| v.to_std())
+                    .map(std::time::Duration::try_from)
                     .transpose()?,
             )
             .with_initial_interval(initial_backoff_duration.unwrap_or(Duration::from_millis(

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -161,7 +161,7 @@ impl<'a> FirestoreTransaction<'a> {
 
         let request = gcloud_sdk::tonic::Request::new(CommitRequest {
             database: self.db.get_database_path().clone(),
-            writes: self.data.writes.drain(..).collect(),
+            writes: std::mem::take(&mut self.data.writes),
             transaction: self.data.transaction_id.clone(),
             request_options: self
                 .db
@@ -248,7 +248,7 @@ impl<'a> FirestoreTransaction<'a> {
             self.data.transaction_id.clone(),
             self.data.document_path.clone(),
             self.data.transaction_span.clone(),
-            self.data.writes.drain(..).collect(),
+            std::mem::take(&mut self.data.writes),
         )
     }
 }

--- a/src/db/transaction_models.rs
+++ b/src/db/transaction_models.rs
@@ -1,6 +1,6 @@
 use crate::errors::FirestoreError;
-use crate::FirestoreDateTime;
 use crate::FirestoreDuration;
+use crate::FirestoreInstant;
 use crate::{FirestoreConsistencySelector, FirestoreRequestOptions, FirestoreWriteResult};
 use rsb_derive::Builder;
 
@@ -142,7 +142,7 @@ pub struct FirestoreTransactionResponse {
     pub write_results: Vec<FirestoreWriteResult>,
     /// The time at which the transaction was committed.
     /// This is `None` if the transaction was read-only or did not involve writes.
-    pub commit_time: Option<FirestoreDateTime>,
+    pub commit_time: Option<FirestoreInstant>,
 }
 
 #[cfg(test)]

--- a/src/db/transaction_models.rs
+++ b/src/db/transaction_models.rs
@@ -1,7 +1,7 @@
 use crate::errors::FirestoreError;
+use crate::FirestoreDateTime;
+use crate::FirestoreDuration;
 use crate::{FirestoreConsistencySelector, FirestoreRequestOptions, FirestoreWriteResult};
-use chrono::prelude::*;
-use chrono::Duration;
 use rsb_derive::Builder;
 
 /// Options for configuring a Firestore transaction.
@@ -17,7 +17,7 @@ pub struct FirestoreTransactionOptions {
     /// An optional maximum duration for the entire transaction, including retries.
     /// If set, the transaction will attempt to complete within this duration.
     /// If `None`, default retry policies of the underlying gRPC client or Firestore service apply.
-    pub max_elapsed_time: Option<Duration>,
+    pub max_elapsed_time: Option<FirestoreDuration>,
 
     /// Concurrent transaction mode
     pub concurrent_mode:
@@ -142,7 +142,7 @@ pub struct FirestoreTransactionResponse {
     pub write_results: Vec<FirestoreWriteResult>,
     /// The time at which the transaction was committed.
     /// This is `None` if the transaction was read-only or did not involve writes.
-    pub commit_time: Option<DateTime<Utc>>,
+    pub commit_time: Option<FirestoreDateTime>,
 }
 
 #[cfg(test)]

--- a/src/db/transform_models.rs
+++ b/src/db/transform_models.rs
@@ -2,7 +2,7 @@ use crate::errors::*;
 use crate::FirestoreValue;
 
 use crate::timestamp_utils::from_timestamp;
-use chrono::prelude::*;
+use crate::FirestoreDateTime;
 use rsb_derive::Builder;
 
 /// The result of a Firestore write operation (create, update, delete).
@@ -15,7 +15,7 @@ pub struct FirestoreWriteResult {
     ///
     /// This is `None` if the write operation did not result in a changed document
     /// (e.g., deleting a non-existent document, or an update that didn't change any values).
-    pub update_time: Option<DateTime<Utc>>,
+    pub update_time: Option<FirestoreDateTime>,
     /// A list of values that are the result of applying field transformations.
     ///
     /// Each [`FirestoreValue`] in this list corresponds to a

--- a/src/db/transform_models.rs
+++ b/src/db/transform_models.rs
@@ -2,7 +2,7 @@ use crate::errors::*;
 use crate::FirestoreValue;
 
 use crate::timestamp_utils::from_timestamp;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use rsb_derive::Builder;
 
 /// The result of a Firestore write operation (create, update, delete).
@@ -15,7 +15,7 @@ pub struct FirestoreWriteResult {
     ///
     /// This is `None` if the write operation did not result in a changed document
     /// (e.g., deleting a non-existent document, or an update that didn't change any values).
-    pub update_time: Option<FirestoreDateTime>,
+    pub update_time: Option<FirestoreInstant>,
     /// A list of values that are the result of applying field transformations.
     ///
     /// Each [`FirestoreValue`] in this list corresponds to a

--- a/src/db/update.rs
+++ b/src/db/update.rs
@@ -1,5 +1,5 @@
 use crate::db::safe_document_path;
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use crate::{FirestoreDb, FirestoreResult, FirestoreWritePrecondition};
 use async_trait::async_trait;
 use gcloud_sdk::google::firestore::v1::*;
@@ -140,13 +140,13 @@ impl FirestoreUpdateSupport for FirestoreDb {
             request_options: self.resolve_request_options(None),
         });
 
-        let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+        let begin_query_utc: FirestoreInstant = FirestoreInstant::now();
         let update_response = self
             .client()
             .get()
             .update_document(update_document_request)
             .await?;
-        let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+        let end_query_utc: FirestoreInstant = FirestoreInstant::now();
         let query_duration = end_query_utc.duration_since(begin_query_utc);
 
         span.record("/firestore/response_time", query_duration.as_millis());

--- a/src/db/update.rs
+++ b/src/db/update.rs
@@ -1,7 +1,7 @@
 use crate::db::safe_document_path;
+use crate::FirestoreDateTime;
 use crate::{FirestoreDb, FirestoreResult, FirestoreWritePrecondition};
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use gcloud_sdk::google::firestore::v1::*;
 use serde::{Deserialize, Serialize};
 use tracing::*;
@@ -140,19 +140,16 @@ impl FirestoreUpdateSupport for FirestoreDb {
             request_options: self.resolve_request_options(None),
         });
 
-        let begin_query_utc: DateTime<Utc> = Utc::now();
+        let begin_query_utc: FirestoreDateTime = FirestoreDateTime::now();
         let update_response = self
             .client()
             .get()
             .update_document(update_document_request)
             .await?;
-        let end_query_utc: DateTime<Utc> = Utc::now();
-        let query_duration = end_query_utc.signed_duration_since(begin_query_utc);
+        let end_query_utc: FirestoreDateTime = FirestoreDateTime::now();
+        let query_duration = end_query_utc.duration_since(begin_query_utc);
 
-        span.record(
-            "/firestore/response_time",
-            query_duration.num_milliseconds(),
-        );
+        span.record("/firestore/response_time", query_duration.as_millis());
 
         span.in_scope(|| {
             debug!(collection_id, document_id, "Updated the document.");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -423,22 +423,11 @@ impl Display for FirestoreCacheError {
 
 impl std::error::Error for FirestoreCacheError {}
 
-impl From<chrono::ParseError> for FirestoreError {
-    fn from(parse_err: chrono::ParseError) -> Self {
+impl From<jiff::Error> for FirestoreError {
+    fn from(err: jiff::Error) -> Self {
         FirestoreError::DeserializeError(FirestoreSerializationError::from_message(format!(
-            "Parse error: {parse_err}"
+            "Date/time error: {err}"
         )))
-    }
-}
-
-impl From<chrono::OutOfRangeError> for FirestoreError {
-    fn from(out_of_range: chrono::OutOfRangeError) -> Self {
-        FirestoreError::InvalidParametersError(FirestoreInvalidParametersError::new(
-            FirestoreInvalidParametersPublicDetails::new(
-                format!("Out of range: {out_of_range}"),
-                "duration".to_string(),
-            ),
-        ))
     }
 }
 
@@ -502,14 +491,14 @@ impl FirestoreErrorInTransaction {
     pub fn retry_after<E: std::error::Error + Send + Sync + 'static>(
         transaction: &FirestoreTransaction,
         source: E,
-        retry_after: chrono::Duration,
+        retry_after: crate::FirestoreDuration,
     ) -> BackoffError<FirestoreError> {
         BackoffError::retry_after(
             FirestoreError::ErrorInTransaction(FirestoreErrorInTransaction {
                 transaction_id: transaction.transaction_id().clone(),
                 source: Box::new(source),
             }),
-            std::time::Duration::from_millis(retry_after.num_milliseconds() as u64),
+            std::time::Duration::from_millis(retry_after.as_millis().unsigned_abs() as u64),
         )
     }
 }

--- a/src/firestore_meta.rs
+++ b/src/firestore_meta.rs
@@ -1,7 +1,7 @@
 use crate::errors::FirestoreError;
 use crate::timestamp_utils::{from_duration, from_timestamp};
 use crate::FirestoreTransactionId;
-use chrono::{DateTime, Duration, Utc};
+use crate::{FirestoreDateTime, FirestoreDuration};
 use gcloud_sdk::google::firestore::v1::{Document, ExplainMetrics, RunQueryResponse};
 use gcloud_sdk::prost_types::value::Kind;
 use rsb_derive::Builder;
@@ -33,7 +33,7 @@ pub struct FirestoreDocumentMetadata {
     /// Present if the request initiated a transaction.
     pub transaction_id: Option<FirestoreTransactionId>,
     /// The time at which the document was read. This may be monotically increasing.
-    pub read_time: Option<DateTime<Utc>>,
+    pub read_time: Option<FirestoreDateTime>,
     /// The number of results that were skipped before returning the first result.
     /// This is relevant for paginated queries or queries with an offset.
     pub skipped_results: usize,
@@ -118,7 +118,7 @@ pub struct FirestoreExecutionStats {
     /// The number of results returned by the query.
     pub results_returned: usize,
     /// The duration it took to execute the query on the server.
-    pub execution_duration: Option<Duration>,
+    pub execution_duration: Option<FirestoreDuration>,
     /// The number of read operations performed by the query.
     pub read_operations: usize,
     /// Additional debugging statistics, represented as a [`FirestoreDynamicStruct`].

--- a/src/firestore_meta.rs
+++ b/src/firestore_meta.rs
@@ -1,7 +1,7 @@
 use crate::errors::FirestoreError;
 use crate::timestamp_utils::{from_duration, from_timestamp};
 use crate::FirestoreTransactionId;
-use crate::{FirestoreDateTime, FirestoreDuration};
+use crate::{FirestoreDuration, FirestoreInstant};
 use gcloud_sdk::google::firestore::v1::{Document, ExplainMetrics, RunQueryResponse};
 use gcloud_sdk::prost_types::value::Kind;
 use rsb_derive::Builder;
@@ -33,7 +33,7 @@ pub struct FirestoreDocumentMetadata {
     /// Present if the request initiated a transaction.
     pub transaction_id: Option<FirestoreTransactionId>,
     /// The time at which the document was read. This may be monotically increasing.
-    pub read_time: Option<FirestoreDateTime>,
+    pub read_time: Option<FirestoreInstant>,
     /// The number of results that were skipped before returning the first result.
     /// This is relevant for paginated queries or queries with an offset.
     pub skipped_results: usize,

--- a/src/firestore_serde/deserializer.rs
+++ b/src/firestore_serde/deserializer.rs
@@ -374,7 +374,7 @@ impl<'de> serde::Deserializer<'de> for FirestoreValue {
                 visitor.visit_map(FirestoreValueMapAccess::new(lat_lng_fields))
             }
             Some(value::ValueType::TimestampValue(ts)) => {
-                visitor.visit_string(from_timestamp(ts)?.to_rfc3339())
+                visitor.visit_string(from_timestamp(ts)?.to_string())
             }
             Some(value::ValueType::FieldReferenceValue(fr)) => visitor.visit_string(fr),
             Some(value::ValueType::FunctionValue(func)) => {

--- a/src/firestore_serde/mod.rs
+++ b/src/firestore_serde/mod.rs
@@ -27,7 +27,7 @@ mod deserializer;
 mod serializer;
 
 /// Provides `#[serde(with = "...")]` serializers and deserializers for Firestore Timestamps
-/// (converting between [`FirestoreDateTime`](crate::FirestoreDateTime) and `google::protobuf::Timestamp`).
+/// (converting between [`FirestoreInstant`](crate::FirestoreInstant) and `google::protobuf::Timestamp`).
 mod timestamp_serializers;
 pub use timestamp_serializers::*;
 

--- a/src/firestore_serde/mod.rs
+++ b/src/firestore_serde/mod.rs
@@ -27,7 +27,7 @@ mod deserializer;
 mod serializer;
 
 /// Provides `#[serde(with = "...")]` serializers and deserializers for Firestore Timestamps
-/// (converting between `chrono::DateTime<Utc>` and `google::protobuf::Timestamp`).
+/// (converting between [`FirestoreDateTime`](crate::FirestoreDateTime) and `google::protobuf::Timestamp`).
 mod timestamp_serializers;
 pub use timestamp_serializers::*;
 

--- a/src/firestore_serde/timestamp_serializers.rs
+++ b/src/firestore_serde/timestamp_serializers.rs
@@ -1,5 +1,6 @@
 use crate::FirestoreInstant;
 use gcloud_sdk::google::firestore::v1::value;
+use rvstruct::ValueStruct;
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::{
@@ -14,12 +15,72 @@ use crate::{
 /// wrapper when you would rather carry the behaviour in the type. It still
 /// serializes as a string to JSON, so the same model can be reused for both
 /// JSON and Firestore.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Default)]
+#[derive(
+    Serialize, Deserialize, Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Default, ValueStruct,
+)]
 pub struct FirestoreTimestamp(pub FirestoreInstant);
 
-impl From<FirestoreInstant> for FirestoreTimestamp {
-    fn from(ts: FirestoreInstant) -> Self {
-        FirestoreTimestamp(ts)
+impl FirestoreTimestamp {
+    /// Returns the current instant.
+    #[inline]
+    pub fn now() -> Self {
+        FirestoreTimestamp(FirestoreInstant::now())
+    }
+}
+
+impl std::fmt::Display for FirestoreTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::str::FromStr for FirestoreTimestamp {
+    type Err = crate::errors::FirestoreError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(FirestoreTimestamp(s.parse::<FirestoreInstant>()?))
+    }
+}
+
+impl From<FirestoreTimestamp> for FirestoreInstant {
+    fn from(ts: FirestoreTimestamp) -> Self {
+        ts.0
+    }
+}
+
+/// Converting to a `SystemTime` is infallible, since every representable
+/// timestamp fits into it.
+impl From<FirestoreTimestamp> for std::time::SystemTime {
+    fn from(ts: FirestoreTimestamp) -> Self {
+        ts.0.into()
+    }
+}
+
+/// Converting from a `SystemTime` is fallible, since it may be outside of the
+/// range supported by Firestore timestamps.
+impl TryFrom<std::time::SystemTime> for FirestoreTimestamp {
+    type Error = crate::errors::FirestoreError;
+
+    fn try_from(system_time: std::time::SystemTime) -> Result<Self, Self::Error> {
+        Ok(FirestoreTimestamp(FirestoreInstant::try_from(system_time)?))
+    }
+}
+
+/// Converts from a Google `prost_types::Timestamp`, as received from Firestore.
+impl TryFrom<gcloud_sdk::prost_types::Timestamp> for FirestoreTimestamp {
+    type Error = crate::errors::FirestoreError;
+
+    fn try_from(ts: gcloud_sdk::prost_types::Timestamp) -> Result<Self, Self::Error> {
+        Ok(FirestoreTimestamp(crate::timestamp_utils::from_timestamp(
+            ts,
+        )?))
+    }
+}
+
+/// Converts into a Google `prost_types::Timestamp`, as sent to Firestore.
+impl From<FirestoreTimestamp> for gcloud_sdk::prost_types::Timestamp {
+    fn from(ts: FirestoreTimestamp) -> Self {
+        crate::timestamp_utils::to_timestamp(ts.0)
     }
 }
 
@@ -366,6 +427,7 @@ mod tests {
         firestore_document_from_serializable, firestore_document_to_serializable, FirestoreInstant,
         FirestoreTimestamp,
     };
+    use rvstruct::ValueStruct;
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -404,6 +466,95 @@ mod tests {
         assert_eq!(deserialized, test_structure);
         // Firestore timestamps keep nanosecond precision
         assert_eq!(deserialized.created_at.subsec_nanosecond(), 123_456_789);
+    }
+
+    #[test]
+    fn test_timestamp_conversions() {
+        use std::str::FromStr;
+        use std::time::SystemTime;
+
+        let ts = FirestoreTimestamp::from_str("2022-12-02T16:53:20.123456789Z").unwrap();
+
+        // Display round trips through FromStr
+        assert_eq!(FirestoreTimestamp::from_str(&ts.to_string()).unwrap(), ts);
+
+        // SystemTime, infallible one way and fallible back
+        let system_time: SystemTime = ts.into();
+        assert_eq!(FirestoreTimestamp::try_from(system_time).unwrap(), ts);
+
+        // Google protobuf timestamps
+        let proto: gcloud_sdk::prost_types::Timestamp = ts.into();
+        assert_eq!(proto.seconds, 1670000000);
+        assert_eq!(proto.nanos, 123_456_789);
+        assert_eq!(FirestoreTimestamp::try_from(proto).unwrap(), ts);
+
+        // The inner instant, both ways
+        let instant: FirestoreInstant = ts.into();
+        assert_eq!(FirestoreTimestamp::from(instant), ts);
+        assert_eq!(ts.value(), &instant);
+
+        assert_eq!(
+            FirestoreTimestamp::try_from(SystemTime::UNIX_EPOCH).unwrap(),
+            FirestoreTimestamp::default()
+        );
+    }
+
+    /// Mirrors the structure used by `examples/timestamp.rs`, so that all three
+    /// documented ways of writing a Firestore timestamp stay verified.
+    #[test]
+    fn test_all_documented_timestamp_forms() {
+        use gcloud_sdk::google::firestore::v1::value::ValueType;
+        use std::time::SystemTime;
+
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+        struct ExampleStructure {
+            some_id: String,
+            created_at: FirestoreTimestamp,
+            updated_at: Option<FirestoreTimestamp>,
+            updated_at_always_none: Option<FirestoreTimestamp>,
+            #[serde(with = "crate::serialize_as_timestamp")]
+            created_at_attr: FirestoreInstant,
+            #[serde(default)]
+            #[serde(with = "crate::serialize_as_optional_timestamp")]
+            updated_at_attr: Option<FirestoreInstant>,
+            #[serde(default)]
+            #[serde(with = "crate::serialize_as_optional_timestamp")]
+            updated_at_attr_always_none: Option<FirestoreInstant>,
+        }
+
+        let from_system_time: FirestoreTimestamp = SystemTime::now().try_into().unwrap();
+
+        let example = ExampleStructure {
+            some_id: "test-1".to_string(),
+            created_at: FirestoreTimestamp::now(),
+            updated_at: Some(from_system_time),
+            updated_at_always_none: None,
+            created_at_attr: FirestoreInstant::now(),
+            updated_at_attr: Some(FirestoreInstant::now()),
+            updated_at_attr_always_none: None,
+        };
+
+        let document = firestore_document_from_serializable("test/doc-id", &example).unwrap();
+
+        // Every populated form must land as a Firestore timestamp value, not a string
+        for field in [
+            "created_at",
+            "updated_at",
+            "created_at_attr",
+            "updated_at_attr",
+        ] {
+            assert!(
+                matches!(
+                    document.fields[field].value_type,
+                    Some(ValueType::TimestampValue(_))
+                ),
+                "{field} must serialize as a Firestore timestamp"
+            );
+        }
+
+        let deserialized: ExampleStructure =
+            firestore_document_to_serializable(&document).expect("Unable to deserialize");
+        assert_eq!(deserialized, example);
     }
 
     #[test]

--- a/src/firestore_serde/timestamp_serializers.rs
+++ b/src/firestore_serde/timestamp_serializers.rs
@@ -1,4 +1,4 @@
-use chrono::prelude::*;
+use crate::FirestoreDateTime;
 use gcloud_sdk::google::firestore::v1::value;
 use serde::{Deserialize, Serialize, Serializer};
 
@@ -7,12 +7,17 @@ use crate::{
     FirestoreValue,
 };
 
+/// A wrapper around [`FirestoreDateTime`] that is always serialized as a
+/// Firestore timestamp value, without needing a `#[serde(with)]` attribute.
+///
+/// It still serializes as a string to JSON, so the same model can be reused for
+/// both JSON and Firestore.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Default)]
-pub struct FirestoreTimestamp(pub DateTime<Utc>);
+pub struct FirestoreTimestamp(pub FirestoreDateTime);
 
-impl From<DateTime<Utc>> for FirestoreTimestamp {
-    fn from(dt: DateTime<Utc>) -> Self {
-        FirestoreTimestamp(dt)
+impl From<FirestoreDateTime> for FirestoreTimestamp {
+    fn from(ts: FirestoreDateTime) -> Self {
+        FirestoreTimestamp(ts)
     }
 }
 
@@ -21,67 +26,64 @@ pub(crate) const FIRESTORE_TS_TYPE_TAG_TYPE: &str = "FirestoreTimestamp";
 pub(crate) const FIRESTORE_TS_NULL_TYPE_TAG_TYPE: &str = "FirestoreTimestampAsNull";
 
 pub mod serialize_as_timestamp {
-    use chrono::{DateTime, Utc};
+    use crate::FirestoreDateTime;
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(ts: &FirestoreDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer
-            .serialize_newtype_struct(crate::firestore_serde::FIRESTORE_TS_TYPE_TAG_TYPE, &date)
+        serializer.serialize_newtype_struct(crate::firestore_serde::FIRESTORE_TS_TYPE_TAG_TYPE, &ts)
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<FirestoreDateTime, D::Error>
     where
         D: Deserializer<'de>,
     {
-        DateTime::<Utc>::deserialize(deserializer)
+        FirestoreDateTime::deserialize(deserializer)
     }
 }
 
 pub mod serialize_as_optional_timestamp {
-    use chrono::{DateTime, Utc};
+    use crate::FirestoreDateTime;
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(ts: &Option<FirestoreDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        match date {
+        match ts {
             Some(v) => serializer
                 .serialize_newtype_struct(crate::firestore_serde::FIRESTORE_TS_TYPE_TAG_TYPE, v),
             None => serializer.serialize_none(),
         }
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<FirestoreDateTime>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Option::<DateTime<Utc>>::deserialize(deserializer)
+        Option::<FirestoreDateTime>::deserialize(deserializer)
     }
 }
 
 pub mod serialize_as_null_timestamp {
-    use chrono::{DateTime, Utc};
+    use crate::FirestoreDateTime;
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(ts: &Option<FirestoreDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.serialize_newtype_struct(
-            crate::firestore_serde::FIRESTORE_TS_NULL_TYPE_TAG_TYPE,
-            date,
-        )
+        serializer
+            .serialize_newtype_struct(crate::firestore_serde::FIRESTORE_TS_NULL_TYPE_TAG_TYPE, ts)
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<FirestoreDateTime>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Option::<DateTime<Utc>>::deserialize(deserializer)
+        Option::<FirestoreDateTime>::deserialize(deserializer)
     }
 }
 
@@ -201,10 +203,10 @@ pub fn serialize_timestamp_for_firestore<T: ?Sized + Serialize>(
         }
 
         fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-            let dt = v.parse::<DateTime<Utc>>()?;
+            let ts = v.parse::<FirestoreDateTime>()?;
             Ok(FirestoreValue::from(
                 gcloud_sdk::google::firestore::v1::Value {
-                    value_type: Some(value::ValueType::TimestampValue(to_timestamp(dt))),
+                    value_type: Some(value::ValueType::TimestampValue(to_timestamp(ts))),
                 },
             ))
         }
@@ -354,4 +356,70 @@ pub fn serialize_timestamp_for_firestore<T: ?Sized + Serialize>(
     }
 
     value.serialize(TimestampSerializer { none_as_null })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        firestore_document_from_serializable, firestore_document_to_serializable,
+        FirestoreDateTime, FirestoreTimestamp,
+    };
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    struct TestStructure {
+        #[serde(with = "crate::serialize_as_timestamp")]
+        created_at: FirestoreDateTime,
+        #[serde(default)]
+        #[serde(with = "crate::serialize_as_optional_timestamp")]
+        updated_at: Option<FirestoreDateTime>,
+        wrapped_at: FirestoreTimestamp,
+    }
+
+    #[test]
+    fn test_timestamp_serde_roundtrip() {
+        let created_at: FirestoreDateTime = "2022-12-02T16:53:20.123456789Z".parse().unwrap();
+        let wrapped_at: FirestoreDateTime = "2018-01-01T00:00:00Z".parse().unwrap();
+
+        let test_structure = TestStructure {
+            created_at,
+            updated_at: Some(created_at),
+            wrapped_at: FirestoreTimestamp(wrapped_at),
+        };
+
+        let document =
+            firestore_document_from_serializable("test/doc-id", &test_structure).unwrap();
+
+        // The timestamps must land as Firestore timestamp values, not as strings
+        assert!(matches!(
+            document.fields["created_at"].value_type,
+            Some(gcloud_sdk::google::firestore::v1::value::ValueType::TimestampValue(_))
+        ));
+
+        let deserialized: TestStructure =
+            firestore_document_to_serializable(&document).expect("Unable to deserialize");
+
+        assert_eq!(deserialized, test_structure);
+        // Firestore timestamps keep nanosecond precision
+        assert_eq!(deserialized.created_at.subsec_nanosecond(), 123_456_789);
+    }
+
+    #[test]
+    fn test_optional_timestamp_none_roundtrip() {
+        let created_at: FirestoreDateTime = "2022-12-02T16:53:20Z".parse().unwrap();
+
+        let test_structure = TestStructure {
+            created_at,
+            updated_at: None,
+            wrapped_at: FirestoreTimestamp(created_at),
+        };
+
+        let document =
+            firestore_document_from_serializable("test/doc-id", &test_structure).unwrap();
+
+        let deserialized: TestStructure =
+            firestore_document_to_serializable(&document).expect("Unable to deserialize");
+
+        assert_eq!(deserialized, test_structure);
+    }
 }

--- a/src/firestore_serde/timestamp_serializers.rs
+++ b/src/firestore_serde/timestamp_serializers.rs
@@ -1,4 +1,4 @@
-use crate::FirestoreDateTime;
+use crate::FirestoreInstant;
 use gcloud_sdk::google::firestore::v1::value;
 use serde::{Deserialize, Serialize, Serializer};
 
@@ -7,16 +7,18 @@ use crate::{
     FirestoreValue,
 };
 
-/// A wrapper around [`FirestoreDateTime`] that is always serialized as a
+/// A wrapper around [`FirestoreInstant`] that is always serialized as a
 /// Firestore timestamp value, without needing a `#[serde(with)]` attribute.
 ///
-/// It still serializes as a string to JSON, so the same model can be reused for
-/// both JSON and Firestore.
+/// Use [`FirestoreInstant`] directly when you prefer the attributes, and this
+/// wrapper when you would rather carry the behaviour in the type. It still
+/// serializes as a string to JSON, so the same model can be reused for both
+/// JSON and Firestore.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Default)]
-pub struct FirestoreTimestamp(pub FirestoreDateTime);
+pub struct FirestoreTimestamp(pub FirestoreInstant);
 
-impl From<FirestoreDateTime> for FirestoreTimestamp {
-    fn from(ts: FirestoreDateTime) -> Self {
+impl From<FirestoreInstant> for FirestoreTimestamp {
+    fn from(ts: FirestoreInstant) -> Self {
         FirestoreTimestamp(ts)
     }
 }
@@ -26,29 +28,29 @@ pub(crate) const FIRESTORE_TS_TYPE_TAG_TYPE: &str = "FirestoreTimestamp";
 pub(crate) const FIRESTORE_TS_NULL_TYPE_TAG_TYPE: &str = "FirestoreTimestampAsNull";
 
 pub mod serialize_as_timestamp {
-    use crate::FirestoreDateTime;
+    use crate::FirestoreInstant;
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(ts: &FirestoreDateTime, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(ts: &FirestoreInstant, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         serializer.serialize_newtype_struct(crate::firestore_serde::FIRESTORE_TS_TYPE_TAG_TYPE, &ts)
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<FirestoreDateTime, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<FirestoreInstant, D::Error>
     where
         D: Deserializer<'de>,
     {
-        FirestoreDateTime::deserialize(deserializer)
+        FirestoreInstant::deserialize(deserializer)
     }
 }
 
 pub mod serialize_as_optional_timestamp {
-    use crate::FirestoreDateTime;
+    use crate::FirestoreInstant;
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(ts: &Option<FirestoreDateTime>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(ts: &Option<FirestoreInstant>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -59,19 +61,19 @@ pub mod serialize_as_optional_timestamp {
         }
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<FirestoreDateTime>, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<FirestoreInstant>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Option::<FirestoreDateTime>::deserialize(deserializer)
+        Option::<FirestoreInstant>::deserialize(deserializer)
     }
 }
 
 pub mod serialize_as_null_timestamp {
-    use crate::FirestoreDateTime;
+    use crate::FirestoreInstant;
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(ts: &Option<FirestoreDateTime>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(ts: &Option<FirestoreInstant>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -79,11 +81,11 @@ pub mod serialize_as_null_timestamp {
             .serialize_newtype_struct(crate::firestore_serde::FIRESTORE_TS_NULL_TYPE_TAG_TYPE, ts)
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<FirestoreDateTime>, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<FirestoreInstant>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Option::<FirestoreDateTime>::deserialize(deserializer)
+        Option::<FirestoreInstant>::deserialize(deserializer)
     }
 }
 
@@ -203,7 +205,7 @@ pub fn serialize_timestamp_for_firestore<T: ?Sized + Serialize>(
         }
 
         fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-            let ts = v.parse::<FirestoreDateTime>()?;
+            let ts = v.parse::<FirestoreInstant>()?;
             Ok(FirestoreValue::from(
                 gcloud_sdk::google::firestore::v1::Value {
                     value_type: Some(value::ValueType::TimestampValue(to_timestamp(ts))),
@@ -361,25 +363,25 @@ pub fn serialize_timestamp_for_firestore<T: ?Sized + Serialize>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        firestore_document_from_serializable, firestore_document_to_serializable,
-        FirestoreDateTime, FirestoreTimestamp,
+        firestore_document_from_serializable, firestore_document_to_serializable, FirestoreInstant,
+        FirestoreTimestamp,
     };
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
     struct TestStructure {
         #[serde(with = "crate::serialize_as_timestamp")]
-        created_at: FirestoreDateTime,
+        created_at: FirestoreInstant,
         #[serde(default)]
         #[serde(with = "crate::serialize_as_optional_timestamp")]
-        updated_at: Option<FirestoreDateTime>,
+        updated_at: Option<FirestoreInstant>,
         wrapped_at: FirestoreTimestamp,
     }
 
     #[test]
     fn test_timestamp_serde_roundtrip() {
-        let created_at: FirestoreDateTime = "2022-12-02T16:53:20.123456789Z".parse().unwrap();
-        let wrapped_at: FirestoreDateTime = "2018-01-01T00:00:00Z".parse().unwrap();
+        let created_at: FirestoreInstant = "2022-12-02T16:53:20.123456789Z".parse().unwrap();
+        let wrapped_at: FirestoreInstant = "2018-01-01T00:00:00Z".parse().unwrap();
 
         let test_structure = TestStructure {
             created_at,
@@ -406,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_optional_timestamp_none_roundtrip() {
-        let created_at: FirestoreDateTime = "2022-12-02T16:53:20Z".parse().unwrap();
+        let created_at: FirestoreInstant = "2022-12-02T16:53:20Z".parse().unwrap();
 
         let test_structure = TestStructure {
             created_at,

--- a/src/fluent_api/tests/mockdb.rs
+++ b/src/fluent_api/tests/mockdb.rs
@@ -80,7 +80,8 @@ impl FirestoreQuerySupport for MockDatabase {
     fn stream_partition_cursors_with_errors(
         &self,
         params: FirestorePartitionQueryParams,
-    ) -> BoxFuture<FirestoreResult<PeekableBoxStream<FirestoreResult<FirestoreQueryCursor>>>> {
+    ) -> BoxFuture<'_, FirestoreResult<PeekableBoxStream<'_, FirestoreResult<FirestoreQueryCursor>>>>
+    {
         unreachable!()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,12 +175,17 @@ pub use struct_path_macro::*;
 /// library is available without depending on `jiff` explicitly.
 pub use jiff;
 
-/// The date/time type used by this library for Firestore timestamps.
+/// An exact instant in time, used by this library for Firestore timestamps.
 ///
-/// This is an alias for [`jiff::Timestamp`], an exact instant in time in UTC.
-/// Prefer this alias over naming `jiff::Timestamp` directly, so that your code
-/// does not need an explicit `jiff` dependency and stays insulated from changes
-/// of the underlying implementation.
+/// This is an alias for [`jiff::Timestamp`]. Prefer this alias over naming
+/// `jiff::Timestamp` directly, so that your code does not need an explicit
+/// `jiff` dependency and stays insulated from changes of the underlying
+/// implementation.
+///
+/// Use it for the fields of your structures. To have a field serialized as a
+/// Firestore timestamp, either annotate it with one of the
+/// [`serialize_as_timestamp`] attributes, or wrap it in
+/// [`FirestoreTimestamp`], which does the same without an attribute.
 ///
 /// # Examples
 ///
@@ -191,14 +196,14 @@ pub use jiff;
 /// #[derive(Debug, Clone, Deserialize, Serialize)]
 /// struct MyTestStructure {
 ///     #[serde(with = "firestore::serialize_as_timestamp")]
-///     created_at: FirestoreDateTime,
+///     created_at: FirestoreInstant,
 ///
 ///     #[serde(default)]
 ///     #[serde(with = "firestore::serialize_as_optional_timestamp")]
-///     updated_at: Option<FirestoreDateTime>,
+///     updated_at: Option<FirestoreInstant>,
 /// }
 /// ```
-pub type FirestoreDateTime = jiff::Timestamp;
+pub type FirestoreInstant = jiff::Timestamp;
 
 /// The duration type used by this library.
 ///
@@ -209,7 +214,7 @@ pub type FirestoreDuration = jiff::SignedDuration;
 
 /// Provides utility functions for working with Firestore timestamps.
 ///
-/// This module includes helpers for converting between [`FirestoreDateTime`]
+/// This module includes helpers for converting between [`FirestoreInstant`]
 /// and Google's `Timestamp` protobuf type, often used with `#[serde(with)]`
 /// attributes for automatic conversion.
 pub mod timestamp_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,9 +171,45 @@ mod struct_path_macro;
 #[allow(unused_imports)]
 pub use struct_path_macro::*;
 
+/// Re-export of the [`jiff`] crate, so that the date/time API used by this
+/// library is available without depending on `jiff` explicitly.
+pub use jiff;
+
+/// The date/time type used by this library for Firestore timestamps.
+///
+/// This is an alias for [`jiff::Timestamp`], an exact instant in time in UTC.
+/// Prefer this alias over naming `jiff::Timestamp` directly, so that your code
+/// does not need an explicit `jiff` dependency and stays insulated from changes
+/// of the underlying implementation.
+///
+/// # Examples
+///
+/// ```rust
+/// use firestore::*;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Debug, Clone, Deserialize, Serialize)]
+/// struct MyTestStructure {
+///     #[serde(with = "firestore::serialize_as_timestamp")]
+///     created_at: FirestoreDateTime,
+///
+///     #[serde(default)]
+///     #[serde(with = "firestore::serialize_as_optional_timestamp")]
+///     updated_at: Option<FirestoreDateTime>,
+/// }
+/// ```
+pub type FirestoreDateTime = jiff::Timestamp;
+
+/// The duration type used by this library.
+///
+/// This is an alias for [`jiff::SignedDuration`], used for values such as
+/// [`FirestoreTransactionOptions::max_elapsed_time`] and the query execution
+/// statistics.
+pub type FirestoreDuration = jiff::SignedDuration;
+
 /// Provides utility functions for working with Firestore timestamps.
 ///
-/// This module includes helpers for converting between `chrono::DateTime<Utc>`
+/// This module includes helpers for converting between [`FirestoreDateTime`]
 /// and Google's `Timestamp` protobuf type, often used with `#[serde(with)]`
 /// attributes for automatic conversion.
 pub mod timestamp_utils;

--- a/src/timestamp_utils.rs
+++ b/src/timestamp_utils.rs
@@ -1,11 +1,11 @@
 use crate::errors::*;
 use crate::FirestoreResult;
-use crate::{FirestoreDateTime, FirestoreDuration};
+use crate::{FirestoreDuration, FirestoreInstant};
 
-/// Converts a Google `prost_types::Timestamp` to a [`FirestoreDateTime`].
+/// Converts a Google `prost_types::Timestamp` to a [`FirestoreInstant`].
 ///
 /// Firestore uses Google's `Timestamp` protobuf message to represent timestamps.
-/// This function facilitates conversion to [`FirestoreDateTime`], the date/time type
+/// This function facilitates conversion to [`FirestoreInstant`], the date/time type
 /// used throughout this library.
 ///
 /// # Arguments
@@ -15,7 +15,7 @@ use crate::{FirestoreDateTime, FirestoreDuration};
 /// A `FirestoreResult` containing the `Timestamp` on success, or a
 /// `FirestoreError::DeserializeError` if the timestamp is invalid or out of range.
 ///
-/// Note that [`FirestoreDateTime`] covers the whole Firestore timestamp range except
+/// Note that [`FirestoreInstant`] covers the whole Firestore timestamp range except
 /// for the last two days of the year 9999, which lie beyond
 /// [`jiff::Timestamp::MAX`]. Such values are reported as an error rather than
 /// being silently truncated.
@@ -29,23 +29,21 @@ use crate::{FirestoreDateTime, FirestoreDuration};
 ///
 /// assert_eq!(timestamp.to_string(), "2022-12-02T16:53:20Z");
 /// ```
-pub fn from_timestamp(
-    ts: gcloud_sdk::prost_types::Timestamp,
-) -> FirestoreResult<FirestoreDateTime> {
-    FirestoreDateTime::new(ts.seconds, ts.nanos).map_err(|err| {
+pub fn from_timestamp(ts: gcloud_sdk::prost_types::Timestamp) -> FirestoreResult<FirestoreInstant> {
+    FirestoreInstant::new(ts.seconds, ts.nanos).map_err(|err| {
         FirestoreError::DeserializeError(FirestoreSerializationError::from_message(format!(
             "Invalid or out-of-range datetime: {ts:?}. {err}"
         )))
     })
 }
 
-/// Converts a [`FirestoreDateTime`] to a Google `prost_types::Timestamp`.
+/// Converts a [`FirestoreInstant`] to a Google `prost_types::Timestamp`.
 ///
 /// This is the reverse of [`from_timestamp`], used when sending timestamp data
 /// to Firestore.
 ///
 /// # Arguments
-/// * `ts`: The [`FirestoreDateTime`] to convert.
+/// * `ts`: The [`FirestoreInstant`] to convert.
 ///
 /// # Returns
 /// The corresponding Google `Timestamp`.
@@ -53,15 +51,15 @@ pub fn from_timestamp(
 /// # Examples
 /// ```rust
 /// use firestore::timestamp_utils::to_timestamp;
-/// use firestore::FirestoreDateTime;
+/// use firestore::FirestoreInstant;
 ///
-/// let timestamp: FirestoreDateTime = "2022-12-02T16:53:20Z".parse().unwrap();
+/// let timestamp: FirestoreInstant = "2022-12-02T16:53:20Z".parse().unwrap();
 /// let prost_timestamp = to_timestamp(timestamp);
 ///
 /// assert_eq!(prost_timestamp.seconds, 1670000000);
 /// assert_eq!(prost_timestamp.nanos, 0);
 /// ```
-pub fn to_timestamp(ts: FirestoreDateTime) -> gcloud_sdk::prost_types::Timestamp {
+pub fn to_timestamp(ts: FirestoreInstant) -> gcloud_sdk::prost_types::Timestamp {
     let seconds = ts.as_second();
     let nanos = ts.subsec_nanosecond();
 
@@ -111,15 +109,15 @@ mod tests {
     fn test_parses_legacy_offset_formats() {
         // Data written by earlier versions used chrono's to_rfc3339(), which emits
         // a numeric +00:00 offset rather than Z.
-        let with_offset: FirestoreDateTime = "2022-12-02T16:53:20+00:00".parse().unwrap();
-        let with_zulu: FirestoreDateTime = "2022-12-02T16:53:20Z".parse().unwrap();
+        let with_offset: FirestoreInstant = "2022-12-02T16:53:20+00:00".parse().unwrap();
+        let with_zulu: FirestoreInstant = "2022-12-02T16:53:20Z".parse().unwrap();
         assert_eq!(with_offset, with_zulu);
 
-        let fractional: FirestoreDateTime = "2022-12-02T16:53:20.123456789+00:00".parse().unwrap();
+        let fractional: FirestoreInstant = "2022-12-02T16:53:20.123456789+00:00".parse().unwrap();
         assert_eq!(fractional.subsec_nanosecond(), 123_456_789);
 
         // Non-UTC offsets must normalise to the same instant
-        let shifted: FirestoreDateTime = "2022-12-02T17:53:20+01:00".parse().unwrap();
+        let shifted: FirestoreInstant = "2022-12-02T17:53:20+01:00".parse().unwrap();
         assert_eq!(shifted, with_zulu);
     }
 
@@ -148,7 +146,7 @@ mod tests {
             nanos: 0,
         };
         let latest_supported = gcloud_sdk::prost_types::Timestamp {
-            seconds: FirestoreDateTime::MAX.as_second(),
+            seconds: FirestoreInstant::MAX.as_second(),
             nanos: 0,
         };
         let out_of_range = gcloud_sdk::prost_types::Timestamp {

--- a/src/timestamp_utils.rs
+++ b/src/timestamp_utils.rs
@@ -1,49 +1,51 @@
 use crate::errors::*;
 use crate::FirestoreResult;
-use chrono::prelude::*;
+use crate::{FirestoreDateTime, FirestoreDuration};
 
-/// Converts a Google `prost_types::Timestamp` to a `chrono::DateTime<Utc>`.
+/// Converts a Google `prost_types::Timestamp` to a [`FirestoreDateTime`].
 ///
 /// Firestore uses Google's `Timestamp` protobuf message to represent timestamps.
-/// This function facilitates conversion to the more commonly used `chrono::DateTime<Utc>`
-/// in Rust applications.
+/// This function facilitates conversion to [`FirestoreDateTime`], the date/time type
+/// used throughout this library.
 ///
 /// # Arguments
 /// * `ts`: The Google `Timestamp` to convert.
 ///
 /// # Returns
-/// A `FirestoreResult` containing the `DateTime<Utc>` on success, or a
+/// A `FirestoreResult` containing the `Timestamp` on success, or a
 /// `FirestoreError::DeserializeError` if the timestamp is invalid or out of range.
+///
+/// Note that [`FirestoreDateTime`] covers the whole Firestore timestamp range except
+/// for the last two days of the year 9999, which lie beyond
+/// [`jiff::Timestamp::MAX`]. Such values are reported as an error rather than
+/// being silently truncated.
 ///
 /// # Examples
 /// ```rust
 /// use firestore::timestamp_utils::from_timestamp;
-/// use chrono::{Utc, TimeZone};
 ///
 /// let prost_timestamp = gcloud_sdk::prost_types::Timestamp { seconds: 1670000000, nanos: 0 };
-/// let chrono_datetime = from_timestamp(prost_timestamp).unwrap();
+/// let timestamp = from_timestamp(prost_timestamp).unwrap();
 ///
-/// assert_eq!(chrono_datetime, Utc.with_ymd_and_hms(2022, 12, 2, 16, 53, 20).unwrap());
+/// assert_eq!(timestamp.to_string(), "2022-12-02T16:53:20Z");
 /// ```
-pub fn from_timestamp(ts: gcloud_sdk::prost_types::Timestamp) -> FirestoreResult<DateTime<Utc>> {
-    if let Some(dt) = chrono::DateTime::from_timestamp(ts.seconds, ts.nanos as u32) {
-        Ok(dt)
-    } else {
-        Err(FirestoreError::DeserializeError(
-            FirestoreSerializationError::from_message(format!(
-                "Invalid or out-of-range datetime: {ts:?}" // Added :? for better debug output
-            )),
-        ))
-    }
+pub fn from_timestamp(
+    ts: gcloud_sdk::prost_types::Timestamp,
+) -> FirestoreResult<FirestoreDateTime> {
+    FirestoreDateTime::new(ts.seconds, ts.nanos).map_err(|err| {
+        FirestoreError::DeserializeError(FirestoreSerializationError::from_message(format!(
+            "Invalid or out-of-range datetime: {ts:?}. {err}"
+        )))
+    })
 }
 
-/// Converts a `chrono::DateTime<Utc>` to a Google `prost_types::Timestamp`.
+/// Converts a [`FirestoreDateTime`] to a Google `prost_types::Timestamp`.
 ///
 /// This is the reverse of [`from_timestamp`], used when sending timestamp data
 /// to Firestore.
 ///
 /// # Arguments
-/// * `dt`: The `chrono::DateTime<Utc>` to convert.
+/// * `ts`: The [`FirestoreDateTime`] to convert.
 ///
 /// # Returns
 /// The corresponding Google `Timestamp`.
@@ -51,22 +53,32 @@ pub fn from_timestamp(ts: gcloud_sdk::prost_types::Timestamp) -> FirestoreResult
 /// # Examples
 /// ```rust
 /// use firestore::timestamp_utils::to_timestamp;
-/// use chrono::{Utc, TimeZone};
+/// use firestore::FirestoreDateTime;
 ///
-/// let chrono_datetime = Utc.with_ymd_and_hms(2022, 12, 2, 16, 53, 20).unwrap();
-/// let prost_timestamp = to_timestamp(chrono_datetime);
+/// let timestamp: FirestoreDateTime = "2022-12-02T16:53:20Z".parse().unwrap();
+/// let prost_timestamp = to_timestamp(timestamp);
 ///
 /// assert_eq!(prost_timestamp.seconds, 1670000000);
 /// assert_eq!(prost_timestamp.nanos, 0);
 /// ```
-pub fn to_timestamp(dt: DateTime<Utc>) -> gcloud_sdk::prost_types::Timestamp {
-    gcloud_sdk::prost_types::Timestamp {
-        seconds: dt.timestamp(),
-        nanos: dt.nanosecond() as i32,
+pub fn to_timestamp(ts: FirestoreDateTime) -> gcloud_sdk::prost_types::Timestamp {
+    let seconds = ts.as_second();
+    let nanos = ts.subsec_nanosecond();
+
+    // Protobuf requires `nanos` to be in the range 0..=999_999_999, while jiff
+    // truncates towards zero and so reports negative subsecond nanoseconds for
+    // instants before the Unix epoch. Normalise those back into the protobuf range.
+    if nanos < 0 {
+        gcloud_sdk::prost_types::Timestamp {
+            seconds: seconds - 1,
+            nanos: nanos + 1_000_000_000,
+        }
+    } else {
+        gcloud_sdk::prost_types::Timestamp { seconds, nanos }
     }
 }
 
-/// Converts a Google `prost_types::Duration` to a `chrono::Duration`.
+/// Converts a Google `prost_types::Duration` to a `FirestoreDuration`.
 ///
 /// Google's `Duration` protobuf message is used in some Firestore contexts,
 /// for example, in query execution statistics.
@@ -75,18 +87,77 @@ pub fn to_timestamp(dt: DateTime<Utc>) -> gcloud_sdk::prost_types::Timestamp {
 /// * `duration`: The Google `Duration` to convert.
 ///
 /// # Returns
-/// The corresponding `chrono::Duration`.
+/// The corresponding `FirestoreDuration`.
 ///
 /// # Examples
 /// ```rust
 /// use firestore::timestamp_utils::from_duration;
+/// use firestore::FirestoreDuration;
 ///
 /// let prost_duration = gcloud_sdk::prost_types::Duration { seconds: 5, nanos: 500_000_000 };
-/// let chrono_duration = from_duration(prost_duration);
+/// let duration = from_duration(prost_duration);
 ///
-/// assert_eq!(chrono_duration, chrono::Duration::milliseconds(5500));
+/// assert_eq!(duration, FirestoreDuration::from_millis(5500));
 /// ```
-pub fn from_duration(duration: gcloud_sdk::prost_types::Duration) -> chrono::Duration {
-    chrono::Duration::seconds(duration.seconds)
-        + chrono::Duration::nanoseconds(duration.nanos.into())
+pub fn from_duration(duration: gcloud_sdk::prost_types::Duration) -> FirestoreDuration {
+    FirestoreDuration::new(duration.seconds, duration.nanos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parses_legacy_offset_formats() {
+        // Data written by earlier versions used chrono's to_rfc3339(), which emits
+        // a numeric +00:00 offset rather than Z.
+        let with_offset: FirestoreDateTime = "2022-12-02T16:53:20+00:00".parse().unwrap();
+        let with_zulu: FirestoreDateTime = "2022-12-02T16:53:20Z".parse().unwrap();
+        assert_eq!(with_offset, with_zulu);
+
+        let fractional: FirestoreDateTime = "2022-12-02T16:53:20.123456789+00:00".parse().unwrap();
+        assert_eq!(fractional.subsec_nanosecond(), 123_456_789);
+
+        // Non-UTC offsets must normalise to the same instant
+        let shifted: FirestoreDateTime = "2022-12-02T17:53:20+01:00".parse().unwrap();
+        assert_eq!(shifted, with_zulu);
+    }
+
+    #[test]
+    fn test_timestamp_roundtrip_including_pre_epoch() {
+        for seconds in [0i64, 1670000000, -1670000000] {
+            let proto = gcloud_sdk::prost_types::Timestamp {
+                seconds,
+                nanos: 123_456_789,
+            };
+            let ts = from_timestamp(proto.clone()).unwrap();
+            let back = to_timestamp(ts);
+            assert_eq!(back.seconds, proto.seconds, "seconds for {seconds}");
+            assert_eq!(back.nanos, proto.nanos, "nanos for {seconds}");
+        }
+    }
+
+    #[test]
+    fn test_firestore_timestamp_range_bounds() {
+        // Firestore documents a range of 0001-01-01 to 9999-12-31, all of which is
+        // representable apart from the last two days of year 9999, which fall outside
+        // of `jiff::Timestamp::MAX`. Out-of-range values produce an error rather than
+        // a silently wrong value.
+        let earliest = gcloud_sdk::prost_types::Timestamp {
+            seconds: -62_135_596_800,
+            nanos: 0,
+        };
+        let latest_supported = gcloud_sdk::prost_types::Timestamp {
+            seconds: FirestoreDateTime::MAX.as_second(),
+            nanos: 0,
+        };
+        let out_of_range = gcloud_sdk::prost_types::Timestamp {
+            seconds: 253_402_300_799,
+            nanos: 999_999_999,
+        };
+
+        assert!(from_timestamp(earliest).is_ok(), "0001-01-01 must parse");
+        assert!(from_timestamp(latest_supported).is_ok());
+        assert!(from_timestamp(out_of_range).is_err());
+    }
 }

--- a/src/timestamp_utils.rs
+++ b/src/timestamp_utils.rs
@@ -130,7 +130,7 @@ mod tests {
                 seconds,
                 nanos: 123_456_789,
             };
-            let ts = from_timestamp(proto.clone()).unwrap();
+            let ts = from_timestamp(proto).unwrap();
             let back = to_timestamp(ts);
             assert_eq!(back.seconds, proto.seconds, "seconds for {seconds}");
             assert_eq!(back.nanos, proto.nanos, "nanos for {seconds}");

--- a/tests/caching_memory_test.rs
+++ b/tests/caching_memory_test.rs
@@ -16,8 +16,8 @@ struct MyTestStructure {
 async fn precondition_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let db = setup().await?;
 
-    const TEST_COLLECTION_NAME_NO_PRELOAD: &'static str = "integration-test-caching-mem-no-preload";
-    const TEST_COLLECTION_NAME_PRELOAD: &'static str = "integration-test-caching-mem-preload";
+    const TEST_COLLECTION_NAME_NO_PRELOAD: &str = "integration-test-caching-mem-no-preload";
+    const TEST_COLLECTION_NAME_PRELOAD: &str = "integration-test-caching-mem-preload";
 
     populate_collection(
         &db,

--- a/tests/caching_persistent_test.rs
+++ b/tests/caching_persistent_test.rs
@@ -18,10 +18,8 @@ struct MyTestStructure {
 async fn precondition_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let db = setup().await?;
 
-    const TEST_COLLECTION_NAME_NO_PRELOAD: &'static str =
-        "integration-test-caching-persistent-no-preload";
-    const TEST_COLLECTION_NAME_PRELOAD: &'static str =
-        "integration-test-caching-persistent-preload";
+    const TEST_COLLECTION_NAME_NO_PRELOAD: &str = "integration-test-caching-persistent-no-preload";
+    const TEST_COLLECTION_NAME_PRELOAD: &str = "integration-test-caching-persistent-preload";
 
     populate_collection(
         &db,

--- a/tests/complex-structure-serialize.rs
+++ b/tests/complex-structure-serialize.rs
@@ -33,13 +33,13 @@ struct MyTestStructure {
     some_string: String,
     some_num: u64,
     #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_optional_timestamp")]
-    updated_at: Option<FirestoreDateTime>,
+    updated_at: Option<FirestoreInstant>,
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_null_timestamp")]
-    updated_at_as_null: Option<FirestoreDateTime>,
+    updated_at_as_null: Option<FirestoreInstant>,
     test1: Test1,
     test1i: Test1i,
     test11: Option<Test1>,
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_id: "test-1".to_string(),
         some_string: "Test".to_string(),
         some_num: 41,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
         updated_at: None,
         updated_at_as_null: None,
         test1: Test1(1),

--- a/tests/complex-structure-serialize.rs
+++ b/tests/complex-structure-serialize.rs
@@ -1,5 +1,4 @@
 use approx::relative_eq;
-use chrono::{DateTime, Utc};
 use firestore::*;
 use serde::{Deserialize, Serialize};
 
@@ -34,13 +33,13 @@ struct MyTestStructure {
     some_string: String,
     some_num: u64,
     #[serde(with = "firestore::serialize_as_timestamp")]
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_optional_timestamp")]
-    updated_at: Option<DateTime<Utc>>,
+    updated_at: Option<FirestoreDateTime>,
     #[serde(default)]
     #[serde(with = "firestore::serialize_as_null_timestamp")]
-    updated_at_as_null: Option<DateTime<Utc>>,
+    updated_at_as_null: Option<FirestoreDateTime>,
     test1: Test1,
     test1i: Test1i,
     test11: Option<Test1>,
@@ -79,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_id: "test-1".to_string(),
         some_string: "Test".to_string(),
         some_num: 41,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
         updated_at: None,
         updated_at_as_null: None,
         test1: Test1(1),

--- a/tests/crud-integration-tests.rs
+++ b/tests/crud-integration-tests.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::test]
@@ -26,7 +26,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string".to_string(),
         one_more_string: "one_more_string".to_string(),
         some_num: 42,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
     };
 
     let my_struct2 = MyTestStructure {
@@ -34,7 +34,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string-1".to_string(),
         one_more_string: "one_more_string-1".to_string(),
         some_num: 17,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
     };
 
     db.fluent()

--- a/tests/crud-integration-tests.rs
+++ b/tests/crud-integration-tests.rs
@@ -1,5 +1,4 @@
 use crate::common::setup;
-use chrono::{DateTime, Utc};
 use firestore::*;
 use futures::stream::BoxStream;
 use futures::StreamExt;
@@ -13,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::test]
@@ -27,7 +26,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string".to_string(),
         one_more_string: "one_more_string".to_string(),
         some_num: 42,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
     };
 
     let my_struct2 = MyTestStructure {
@@ -35,7 +34,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string-1".to_string(),
         one_more_string: "one_more_string-1".to_string(),
         some_num: 17,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
     };
 
     db.fluent()

--- a/tests/crud-integration-tests.rs
+++ b/tests/crud-integration-tests.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::test]
@@ -26,7 +26,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string".to_string(),
         one_more_string: "one_more_string".to_string(),
         some_num: 42,
-        created_at: FirestoreInstant::now(),
+        created_at: FirestoreTimestamp::now(),
     };
 
     let my_struct2 = MyTestStructure {
@@ -34,7 +34,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string-1".to_string(),
         one_more_string: "one_more_string-1".to_string(),
         some_num: 17,
-        created_at: FirestoreInstant::now(),
+        created_at: FirestoreTimestamp::now(),
     };
 
     db.fluent()

--- a/tests/query-integration-tests.rs
+++ b/tests/query-integration-tests.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreDateTime,
+    created_at: FirestoreInstant,
 }
 
 #[tokio::test]
@@ -26,7 +26,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string".to_string(),
         one_more_string: "one_more_string".to_string(),
         some_num: 42,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
     };
 
     let my_struct2 = MyTestStructure {
@@ -34,7 +34,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string-1".to_string(),
         one_more_string: "one_more_string-1".to_string(),
         some_num: 17,
-        created_at: FirestoreDateTime::now(),
+        created_at: FirestoreInstant::now(),
     };
 
     db.fluent()

--- a/tests/query-integration-tests.rs
+++ b/tests/query-integration-tests.rs
@@ -1,5 +1,4 @@
 use crate::common::setup;
-use chrono::prelude::*;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -13,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: DateTime<Utc>,
+    created_at: FirestoreDateTime,
 }
 
 #[tokio::test]
@@ -27,7 +26,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string".to_string(),
         one_more_string: "one_more_string".to_string(),
         some_num: 42,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
     };
 
     let my_struct2 = MyTestStructure {
@@ -35,7 +34,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string-1".to_string(),
         one_more_string: "one_more_string-1".to_string(),
         some_num: 17,
-        created_at: Utc::now(),
+        created_at: FirestoreDateTime::now(),
     };
 
     db.fluent()

--- a/tests/query-integration-tests.rs
+++ b/tests/query-integration-tests.rs
@@ -12,7 +12,7 @@ struct MyTestStructure {
     some_string: String,
     one_more_string: String,
     some_num: u64,
-    created_at: FirestoreInstant,
+    created_at: FirestoreTimestamp,
 }
 
 #[tokio::test]
@@ -26,7 +26,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string".to_string(),
         one_more_string: "one_more_string".to_string(),
         some_num: 42,
-        created_at: FirestoreInstant::now(),
+        created_at: FirestoreTimestamp::now(),
     };
 
     let my_struct2 = MyTestStructure {
@@ -34,7 +34,7 @@ async fn crud_tests() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         some_string: "some_string-1".to_string(),
         one_more_string: "one_more_string-1".to_string(),
         some_num: 17,
-        created_at: FirestoreInstant::now(),
+        created_at: FirestoreTimestamp::now(),
     };
 
     db.fluent()


### PR DESCRIPTION
Migrates the library from `chrono` to `jiff`, following gcloud-sdk which has already migrated.

`FirestoreTimestamp` becomes the primary way of working with timestamps and no longer needs an attribute:

```rust
#[derive(Debug, Clone, Deserialize, Serialize)]
struct MyTestStructure {
    created_at: FirestoreTimestamp,
    updated_at: Option<FirestoreTimestamp>,
}

let now = FirestoreTimestamp::now();
let from_system_time: FirestoreTimestamp = SystemTime::now().try_into()?;
let back_to_system_time: SystemTime = now.into();
```

It also gained `Display`, `FromStr`, the `value()`/`into_value()` accessors, and conversions from and to the Google protobuf timestamps.

Two aliases are introduced so that the date/time API is usable without depending on `jiff` explicitly, and so the underlying implementation can change without breaking users again. `FirestoreInstant` is only needed when using the serde attributes:

```rust
pub type FirestoreInstant = jiff::Timestamp;
pub type FirestoreDuration = jiff::SignedDuration;

#[serde(with = "firestore::serialize_as_timestamp")]
created_at: FirestoreInstant,
```

The `jiff` crate itself is re-exported too.

### Breaking changes

`FirestoreTimestamp`, the `serialize_as_timestamp` attributes, `timestamp_utils`, `FirestoreTransactionOptions::max_elapsed_time` and the `commit_time`/`read_time`/`update_time` fields all change their type.

Existing data stays readable: `jiff` parses everything the previous implementation produced, including numeric `+00:00` offsets, and resolves them to the same instant. Newly written values use the `Z` suffix.

### Behaviour notes

- `jiff` truncates towards zero and so reports negative subsecond nanoseconds for instants before the Unix epoch, while protobuf requires them in `0..=999_999_999`. `to_timestamp` normalises those.
- `jiff::Timestamp` covers the whole Firestore range except the last two days of year 9999, which are now reported as an error instead of being silently truncated.
- `FirestoreError::retry_after` previously cast a negative duration to `u64`, producing an effectively infinite backoff. It now takes the absolute value.

### Testing

`cargo fmt --check`, `cargo clippy --all-targets --all-features`, 24 lib tests and 17 doctests pass. New unit tests cover the timestamp serde round trip with nanosecond precision, all three documented ways of writing a timestamp, the SystemTime and protobuf conversions, parsing of the formats written by the previous implementation, pre-epoch round trips, and the range bounds. The `timestamp`, `crud` and `request-tags` examples were also run against a real Firestore project.
