### PR TITLE
fix: Do not require credentials for the Firestore emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,7 +734,13 @@ To work with the Google Firestore emulator you can use the environment variable:
 export FIRESTORE_EMULATOR_HOST="localhost:8080"
 ```
 
-or specify it as an option using `FirestoreDb::with_options()`
+or specify it as an option using `FirestoreDb::with_options()`.
+
+When `FIRESTORE_EMULATOR_HOST` is set, the library does not look up the Google
+credentials and uses a stub token instead, since the emulator does not
+authenticate the requests. This means you do not need any credentials
+configured to develop against it. Specifying a token source explicitly, with
+`FirestoreDb::with_options_token_source()` for example, still takes precedence.
 
 ## Caching
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -134,6 +134,27 @@ pub struct FirestoreDb {
 const GOOGLE_FIREBASE_API_URL: &str = "https://firestore.googleapis.com";
 const GOOGLE_FIRESTORE_EMULATOR_HOST_ENV: &str = "FIRESTORE_EMULATOR_HOST";
 
+/// The token the Firebase tools conventionally send to the local emulators,
+/// which do not authenticate the requests.
+const GOOGLE_FIRESTORE_EMULATOR_TOKEN: &str = "owner";
+
+/// A stub token source used when talking to the Firestore emulator.
+///
+/// The emulator does not verify the credentials, and looking up the real ones
+/// would only fail on a development machine that has none configured.
+struct FirestoreEmulatorTokenSource;
+
+#[async_trait::async_trait]
+impl gcloud_sdk::Source for FirestoreEmulatorTokenSource {
+    async fn token(&self) -> gcloud_sdk::error::Result<gcloud_sdk::Token> {
+        Ok(gcloud_sdk::Token::new(
+            "Bearer".to_string(),
+            GOOGLE_FIRESTORE_EMULATOR_TOKEN.to_string().into(),
+            jiff::Timestamp::MAX,
+        ))
+    }
+}
+
 impl FirestoreDb {
     /// Creates a new `FirestoreDb` instance with the specified Google Project ID.
     ///
@@ -239,15 +260,26 @@ impl FirestoreDb {
         );
         let firestore_database_doc_path = format!("{firestore_database_path}/documents");
 
+        let emulator_host = std::env::var(GOOGLE_FIRESTORE_EMULATOR_HOST_ENV).ok();
+
         let effective_firebase_api_url = options
             .firebase_api_url
             .clone()
-            .or_else(|| {
-                std::env::var(GOOGLE_FIRESTORE_EMULATOR_HOST_ENV)
-                    .ok()
-                    .map(ensure_url_scheme)
-            })
+            .or_else(|| emulator_host.clone().map(ensure_url_scheme))
             .unwrap_or_else(|| GOOGLE_FIREBASE_API_URL.to_string());
+
+        // The emulator does not authenticate the requests, and there are usually no
+        // credentials available when developing against it, so looking them up would
+        // only fail. An explicitly specified token source is still respected.
+        let effective_token_source_type =
+            if emulator_host.is_some() && matches!(token_source_type, TokenSourceType::Default) {
+                debug!(
+                "Firestore emulator detected, skipping the token source and using a stub token.",
+            );
+                TokenSourceType::ExternalSource(Box::new(FirestoreEmulatorTokenSource))
+            } else {
+                token_source_type
+            };
 
         info!(
             database_path = firestore_database_path,
@@ -261,7 +293,7 @@ impl FirestoreDb {
             effective_firebase_api_url,
             Some(firestore_database_path.clone()),
             token_scopes,
-            token_source_type,
+            effective_token_source_type,
         )
         .await?;
 
@@ -694,6 +726,22 @@ pub(crate) fn split_document_path(path: &str) -> (&str, &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_emulator_token_source() {
+        use gcloud_sdk::Source;
+
+        let token = FirestoreEmulatorTokenSource
+            .token()
+            .await
+            .expect("The emulator token source must never fail");
+
+        assert_eq!(token.token_type, "Bearer");
+        assert_eq!(
+            token.token.as_sensitive_str(),
+            GOOGLE_FIRESTORE_EMULATOR_TOKEN
+        );
+    }
 
     #[test]
     fn test_safe_document_path() {


### PR DESCRIPTION
Fixes #216 and #137.

Using the library against the Firestore emulator failed unless Google credentials happened to be configured, with:

```
SystemError(FirestoreSystemError { code: "TokenSource", message: "token source error: not found token source" })
```

The emulator does not authenticate the requests, so looking the credentials up could only fail on a development machine that has none.

When `FIRESTORE_EMULATOR_HOST` is set, the library now uses a stub token (`owner`, the one the Firebase tools send to the local emulators) instead of resolving the real credentials. Specifying a token source explicitly, with `with_options_token_source()` for example, still takes precedence.

### Testing

Verified against a real Firestore emulator with no credentials available at all (no `GOOGLE_APPLICATION_CREDENTIALS`, no application default credentials).

Before, the client failed to be created with the token source error above. After, the following examples all pass:

- `crud`, covering create, get, update and delete
- `transactions`
- `aggregated-query`
- `list-docs`
- `document-transform`

This also answers the question raised in #137 about whether the emulator needs a valid token for some operations. At least for everything above, it does not.
