### PR TITLE
feat: Automatic support for std::time::SystemTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,11 +263,8 @@ struct MyTestStructure {
 }
 ```
 
-  Reading accepts both the native timestamps and the two field
-  `{ secs_since_epoch, nanos_since_epoch }` maps written by the earlier versions,
-  so the existing documents keep working without a migration. Note that
-  `SystemTime` cannot carry the instants before the Unix epoch, since serde itself
-  refuses them.
+  Note that `SystemTime` cannot carry the instants before the Unix epoch, since
+  serde itself refuses them.
 
 - Using the type `FirestoreTimestamp`, which needs no attributes:
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ struct MyTestStructure {
 }
 ```
 
+  It works in the queries as well:
+
+```rust
+   q.field(path!(MyTestStructure::created_at)).less_than_or_equal(SystemTime::now())
+```
+
   Note that `SystemTime` cannot carry the instants before the Unix epoch, since
   serde itself refuses them.
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,24 @@ let object_stream: BoxStream<(String, Option<MyTestStructure>) > = db.fluent()
 
 By default, date/time values serialize as a string to Firestore (while
 deserialization works from Timestamps and Strings). To store them as native
-Firestore timestamps there are two options.
+Firestore timestamps there are three options.
+
+- Using `std::time::SystemTime` directly, with no attribute and no wrapping type,
+  since it is recognised automatically:
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct MyTestStructure {
+    created_at: SystemTime,
+    updated_at: Option<SystemTime>
+}
+```
+
+  Reading accepts both the native timestamps and the two field
+  `{ secs_since_epoch, nanos_since_epoch }` maps written by the earlier versions,
+  so the existing documents keep working without a migration. Note that
+  `SystemTime` cannot carry the instants before the Unix epoch, since serde itself
+  refuses them.
 
 - Using the type `FirestoreTimestamp`, which needs no attributes:
 
@@ -293,9 +310,10 @@ struct MyTestStructure {
 }
 ```
 
-Both change the representation only for Firestore serialization, and still
-serialize as a string to JSON, so the same model can be reused for JSON and
-Firestore.
+All of them change the representation only for Firestore serialization.
+`FirestoreTimestamp` and `FirestoreInstant` still serialize as a string to JSON,
+so the same model can be reused for JSON and Firestore, while a plain `SystemTime`
+keeps the default serde representation.
 
 ## Nested collections
 

--- a/examples/timestamp.rs
+++ b/examples/timestamp.rs
@@ -11,6 +11,10 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
 struct MyTestStructure {
     some_id: String,
 
+    // The zero effort option: a plain `SystemTime` is stored as a native
+    // Firestore timestamp, with no attribute and no wrapping type.
+    created_at_system_time: SystemTime,
+
     // The simplest option: the wrapping type serializes as a Firestore timestamp
     // without any attribute. For serde_json it is still a string, so the same
     // model can be reused for both JSON and Firestore.
@@ -51,6 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let my_struct = MyTestStructure {
         some_id: "test-1".to_string(),
+        created_at_system_time: SystemTime::now(),
         created_at: FirestoreTimestamp::now(),
         updated_at: Some(now_from_system_time),
         updated_at_always_none: None,

--- a/examples/timestamp.rs
+++ b/examples/timestamp.rs
@@ -106,5 +106,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     println!("Now in the list: {objects1:?}");
 
+    // A plain `SystemTime` works in the queries as well
+    let objects2: Vec<MyTestStructure> = db
+        .fluent()
+        .select()
+        .from(TEST_COLLECTION_NAME)
+        .filter(|q| {
+            q.for_all([q
+                .field(path!(MyTestStructure::created_at_system_time))
+                .less_than_or_equal(SystemTime::now())])
+        })
+        .obj()
+        .query()
+        .await?;
+
+    println!("Found by a SystemTime filter: {objects2:?}");
+
     Ok(())
 }

--- a/src/firestore_serde/deserializer.rs
+++ b/src/firestore_serde/deserializer.rs
@@ -664,13 +664,29 @@ impl<'de> serde::Deserializer<'de> for FirestoreValue {
 
     fn deserialize_struct<V>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
+        // Serde models `std::time::SystemTime` as a two field structure, so a
+        // native Firestore timestamp has to be expanded back into it. Everything
+        // else, including the two field map written by the earlier versions of
+        // this library, keeps going through `deserialize_any`.
+        if name
+            == crate::firestore_serde::system_time_serializers::FIRESTORE_SYSTEM_TIME_TYPE_TAG_TYPE
+        {
+            if let Some(value::ValueType::TimestampValue(ts)) = &self.value.value_type {
+                let parts =
+                    crate::firestore_serde::system_time_serializers::timestamp_to_system_time_parts(
+                        *ts,
+                    )?;
+                return visitor.visit_seq(FirestoreValueSeqAccess::new(parts));
+            }
+        }
+
         self.deserialize_any(visitor)
     }
 

--- a/src/firestore_serde/deserializer.rs
+++ b/src/firestore_serde/deserializer.rs
@@ -673,8 +673,7 @@ impl<'de> serde::Deserializer<'de> for FirestoreValue {
     {
         // Serde models `std::time::SystemTime` as a two field structure, so a
         // native Firestore timestamp has to be expanded back into it. Everything
-        // else, including the two field map written by the earlier versions of
-        // this library, keeps going through `deserialize_any`.
+        // else keeps going through `deserialize_any`.
         if name
             == crate::firestore_serde::system_time_serializers::FIRESTORE_SYSTEM_TIME_TYPE_TAG_TYPE
         {

--- a/src/firestore_serde/mod.rs
+++ b/src/firestore_serde/mod.rs
@@ -51,6 +51,10 @@ pub use reference_serializers::*;
 mod vector_serializers;
 pub use vector_serializers::*;
 
+/// Provides automatic Firestore timestamp support for `std::time::SystemTime`,
+/// without attributes or wrapping types.
+mod system_time_serializers;
+
 use crate::FirestoreValue;
 use gcloud_sdk::google::firestore::v1::Value;
 

--- a/src/firestore_serde/serializer.rs
+++ b/src/firestore_serde/serializer.rs
@@ -31,6 +31,11 @@ pub struct SerializeMap {
     none_as_null: bool,
     fields: HashMap<String, gcloud_sdk::google::firestore::v1::Value>,
     next_key: Option<String>,
+    /// The structure name given to `serialize_struct`, or `None` when this came
+    /// from `serialize_map`. Used to recognise the well known structure shapes,
+    /// such as `std::time::SystemTime`, and to fold them into the native
+    /// Firestore values.
+    struct_name: Option<&'static str>,
 }
 
 pub struct SerializeStructVariant {
@@ -291,15 +296,21 @@ impl serde::Serializer for FirestoreValueSerializer {
             none_as_null: self.none_as_null,
             fields: HashMap::with_capacity(len.unwrap_or(0)),
             next_key: None,
+            struct_name: None,
         })
     }
 
     fn serialize_struct(
         self,
-        _name: &'static str,
+        name: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        self.serialize_map(Some(len))
+        Ok(SerializeMap {
+            none_as_null: self.none_as_null,
+            fields: HashMap::with_capacity(len),
+            next_key: None,
+            struct_name: Some(name),
+        })
     }
 
     fn serialize_struct_variant(
@@ -481,6 +492,22 @@ impl serde::ser::SerializeStruct for SerializeMap {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
+        // Serde models `std::time::SystemTime` as a structure, so recognise it
+        // here and store it as a native Firestore timestamp instead of a map.
+        if self.struct_name
+            == Some(
+                crate::firestore_serde::system_time_serializers::FIRESTORE_SYSTEM_TIME_TYPE_TAG_TYPE,
+            )
+        {
+            if let Some(timestamp_value) =
+                crate::firestore_serde::system_time_serializers::system_time_fields_to_timestamp_value(
+                    &self.fields,
+                )?
+            {
+                return Ok(FirestoreValue::from(timestamp_value));
+            }
+        }
+
         Ok(FirestoreValue::from(
             gcloud_sdk::google::firestore::v1::Value {
                 value_type: Some(value::ValueType::MapValue(

--- a/src/firestore_serde/system_time_serializers.rs
+++ b/src/firestore_serde/system_time_serializers.rs
@@ -218,6 +218,24 @@ mod tests {
     }
 
     #[test]
+    fn test_system_time_as_a_query_value() {
+        use crate::FirestoreValue;
+
+        // Query filters take anything convertible into a `FirestoreValue`, which
+        // goes through the same serializer, so a `SystemTime` can be compared
+        // against a stored timestamp directly.
+        let value: FirestoreValue = sample_time().into();
+
+        match value.value.value_type {
+            Some(ValueType::TimestampValue(ts)) => {
+                assert_eq!(ts.seconds, 1_670_000_000);
+                assert_eq!(ts.nanos, 123_456_789);
+            }
+            ref other => panic!("a SystemTime query value must be a timestamp, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_user_structure_named_system_time_is_not_intercepted() {
         // Only the shape serde produces is folded, so a structure that merely
         // shares the name keeps serializing as an ordinary map.

--- a/src/firestore_serde/system_time_serializers.rs
+++ b/src/firestore_serde/system_time_serializers.rs
@@ -1,0 +1,336 @@
+//! Automatic support for `std::time::SystemTime`.
+//!
+//! Serde models `SystemTime` as a two field structure named `SystemTime`,
+//! carrying `secs_since_epoch` and `nanos_since_epoch`. Both the Firestore
+//! serializer and the deserializer recognise that shape and map it to a native
+//! Firestore timestamp instead, so a plain `SystemTime` field needs neither an
+//! attribute nor a wrapping type.
+//!
+//! Reading is deliberately lenient: a native timestamp is preferred, but the two
+//! field map written by the earlier versions of this library is still accepted,
+//! so the existing documents keep working without a migration.
+
+use std::collections::HashMap;
+
+use gcloud_sdk::google::firestore::v1::value;
+use gcloud_sdk::google::firestore::v1::Value;
+
+use crate::errors::{FirestoreError, FirestoreSerializationError};
+use crate::timestamp_utils::to_timestamp;
+use crate::FirestoreInstant;
+
+/// The structure name serde uses for `std::time::SystemTime`.
+pub(crate) const FIRESTORE_SYSTEM_TIME_TYPE_TAG_TYPE: &str = "SystemTime";
+
+/// The field names serde uses for `std::time::SystemTime`.
+const FIRESTORE_SYSTEM_TIME_SECS_FIELD: &str = "secs_since_epoch";
+const FIRESTORE_SYSTEM_TIME_NANOS_FIELD: &str = "nanos_since_epoch";
+
+/// Folds the fields collected for a structure named `SystemTime` into a native
+/// Firestore timestamp.
+///
+/// Returns `Ok(None)` when the fields do not have the exact shape serde produces
+/// for `std::time::SystemTime`, in which case the caller keeps the previous
+/// behaviour and writes an ordinary map. That keeps a user defined structure
+/// that merely happens to have the same name working unchanged.
+pub(crate) fn system_time_fields_to_timestamp_value(
+    fields: &HashMap<String, Value>,
+) -> Result<Option<Value>, FirestoreError> {
+    if fields.len() != 2 {
+        return Ok(None);
+    }
+
+    let (secs, nanos) = match (
+        fields
+            .get(FIRESTORE_SYSTEM_TIME_SECS_FIELD)
+            .and_then(|v| v.value_type.as_ref()),
+        fields
+            .get(FIRESTORE_SYSTEM_TIME_NANOS_FIELD)
+            .and_then(|v| v.value_type.as_ref()),
+    ) {
+        (
+            Some(value::ValueType::IntegerValue(secs)),
+            Some(value::ValueType::IntegerValue(nanos)),
+        ) => (*secs, *nanos),
+        _ => return Ok(None),
+    };
+
+    // Serde widens both fields from unsigned values, so anything negative here
+    // cannot have come from a real `SystemTime` and is left alone as a map.
+    let (Ok(secs), Ok(nanos)) = (u64::try_from(secs), u32::try_from(nanos)) else {
+        return Ok(None);
+    };
+
+    Ok(Some(Value {
+        value_type: Some(value::ValueType::TimestampValue(epoch_offset_to_timestamp(
+            secs, nanos,
+        )?)),
+    }))
+}
+
+/// Converts an offset from the Unix epoch, as serde reports it for
+/// `std::time::SystemTime`, into a Google `prost_types::Timestamp`.
+fn epoch_offset_to_timestamp(
+    secs_since_epoch: u64,
+    nanos_since_epoch: u32,
+) -> Result<gcloud_sdk::prost_types::Timestamp, FirestoreError> {
+    // Subsecond nanoseconds never reach a full second, but normalise defensively
+    // so that the protobuf range is always respected.
+    let carry_secs = u64::from(nanos_since_epoch / 1_000_000_000);
+    let nanos = (nanos_since_epoch % 1_000_000_000) as i32;
+
+    let seconds = secs_since_epoch
+        .checked_add(carry_secs)
+        .and_then(|secs| i64::try_from(secs).ok())
+        .ok_or_else(|| {
+            FirestoreError::SerializeError(FirestoreSerializationError::from_message(format!(
+                "SystemTime is too far in the future to be a Firestore timestamp: \
+                 {secs_since_epoch}s {nanos_since_epoch}ns since the Unix epoch"
+            )))
+        })?;
+
+    // Going through `FirestoreInstant` keeps the accepted range identical to
+    // every other timestamp of this library, and reports the out of range values
+    // here instead of failing on the server side.
+    let instant = FirestoreInstant::new(seconds, nanos).map_err(|err| {
+        FirestoreError::SerializeError(FirestoreSerializationError::from_message(format!(
+            "Invalid or out-of-range SystemTime: {seconds}s {nanos}ns since the Unix epoch. {err}"
+        )))
+    })?;
+
+    Ok(to_timestamp(instant))
+}
+
+/// Expands a Firestore timestamp into the sequence of the seconds and the
+/// nanoseconds since the Unix epoch that serde expects for
+/// `std::time::SystemTime`.
+pub(crate) fn timestamp_to_system_time_parts(
+    ts: gcloud_sdk::prost_types::Timestamp,
+) -> Result<Vec<Value>, FirestoreError> {
+    // Normalise a negative subsecond part back into the protobuf range first,
+    // mirroring `timestamp_utils::to_timestamp`.
+    let (seconds, nanos) = if ts.nanos < 0 {
+        (ts.seconds - 1, ts.nanos + 1_000_000_000)
+    } else {
+        (ts.seconds, ts.nanos)
+    };
+
+    if seconds < 0 {
+        return Err(FirestoreError::DeserializeError(
+            FirestoreSerializationError::from_message(format!(
+                "`std::time::SystemTime` cannot represent the timestamp {seconds}s {nanos}ns, \
+                 since serde only supports the instants at or after the Unix epoch. \
+                 Use `FirestoreTimestamp` or `FirestoreInstant` for the earlier dates."
+            )),
+        ));
+    }
+
+    Ok(vec![
+        Value {
+            value_type: Some(value::ValueType::IntegerValue(seconds)),
+        },
+        Value {
+            value_type: Some(value::ValueType::IntegerValue(i64::from(nanos))),
+        },
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{firestore_document_from_serializable, firestore_document_to_serializable};
+    use gcloud_sdk::google::firestore::v1::value::ValueType;
+    use gcloud_sdk::google::firestore::v1::{Document, MapValue, Value};
+    use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    struct NestedStructure {
+        touched_at: SystemTime,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    struct TestStructure {
+        created_at: SystemTime,
+        updated_at: Option<SystemTime>,
+        deleted_at: Option<SystemTime>,
+        history: Vec<SystemTime>,
+        nested: NestedStructure,
+    }
+
+    fn sample_time() -> SystemTime {
+        UNIX_EPOCH + Duration::new(1_670_000_000, 123_456_789)
+    }
+
+    #[test]
+    fn test_system_time_serde_roundtrip() {
+        let test_structure = TestStructure {
+            created_at: sample_time(),
+            updated_at: Some(sample_time() + Duration::from_secs(60)),
+            deleted_at: None,
+            history: vec![sample_time(), UNIX_EPOCH],
+            nested: NestedStructure {
+                touched_at: sample_time(),
+            },
+        };
+
+        let document =
+            firestore_document_from_serializable("test/doc-id", &test_structure).unwrap();
+
+        // A plain `SystemTime` must land as a native timestamp, not as a map
+        match document.fields["created_at"].value_type {
+            Some(ValueType::TimestampValue(ts)) => {
+                assert_eq!(ts.seconds, 1_670_000_000);
+                assert_eq!(ts.nanos, 123_456_789);
+            }
+            ref other => panic!("created_at must be a timestamp value, got {other:?}"),
+        }
+
+        // Optionals, sequences and the nested structures go the same way
+        assert!(matches!(
+            document.fields["updated_at"].value_type,
+            Some(ValueType::TimestampValue(_))
+        ));
+        assert!(!document.fields.contains_key("deleted_at"));
+
+        match document.fields["history"].value_type {
+            Some(ValueType::ArrayValue(ref array)) => {
+                assert_eq!(array.values.len(), 2);
+                for element in &array.values {
+                    assert!(matches!(
+                        element.value_type,
+                        Some(ValueType::TimestampValue(_))
+                    ));
+                }
+            }
+            ref other => panic!("history must be an array value, got {other:?}"),
+        }
+
+        match document.fields["nested"].value_type {
+            Some(ValueType::MapValue(ref map)) => assert!(matches!(
+                map.fields["touched_at"].value_type,
+                Some(ValueType::TimestampValue(_))
+            )),
+            ref other => panic!("nested must be a map value, got {other:?}"),
+        }
+
+        let deserialized: TestStructure =
+            firestore_document_to_serializable(&document).expect("Unable to deserialize");
+        assert_eq!(deserialized, test_structure);
+    }
+
+    #[test]
+    fn test_legacy_system_time_map_still_deserializes() {
+        // The documents written by the earlier versions carry the two field map
+        // serde produces by default, and must keep working without a migration.
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+        struct LegacyStructure {
+            created_at: SystemTime,
+            updated_at: Option<SystemTime>,
+        }
+
+        let legacy_fields: HashMap<String, Value> = vec![
+            (
+                "secs_since_epoch".to_string(),
+                Value {
+                    value_type: Some(ValueType::IntegerValue(1_670_000_000)),
+                },
+            ),
+            (
+                "nanos_since_epoch".to_string(),
+                Value {
+                    value_type: Some(ValueType::IntegerValue(123_456_789)),
+                },
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let document = Document {
+            name: "test/doc-id".to_string(),
+            fields: vec![(
+                "created_at".to_string(),
+                Value {
+                    value_type: Some(ValueType::MapValue(MapValue {
+                        fields: legacy_fields,
+                    })),
+                },
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+
+        let deserialized: LegacyStructure =
+            firestore_document_to_serializable(&document).expect("Unable to deserialize");
+        assert_eq!(deserialized.created_at, sample_time());
+        assert_eq!(deserialized.updated_at, None);
+    }
+
+    #[test]
+    fn test_user_structure_named_system_time_is_not_intercepted() {
+        // Only the shape serde produces is folded, so a structure that merely
+        // shares the name keeps serializing as an ordinary map.
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+        #[serde(rename = "SystemTime")]
+        struct MachineTime {
+            host: String,
+            uptime_secs: u64,
+        }
+
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+        struct Wrapper {
+            machine: MachineTime,
+        }
+
+        let wrapper = Wrapper {
+            machine: MachineTime {
+                host: "localhost".to_string(),
+                uptime_secs: 42,
+            },
+        };
+
+        let document = firestore_document_from_serializable("test/doc-id", &wrapper).unwrap();
+        assert!(matches!(
+            document.fields["machine"].value_type,
+            Some(ValueType::MapValue(_))
+        ));
+
+        let deserialized: Wrapper = firestore_document_to_serializable(&document).unwrap();
+        assert_eq!(deserialized, wrapper);
+    }
+
+    #[test]
+    fn test_pre_epoch_system_time_is_rejected() {
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        struct Wrapper {
+            created_at: SystemTime,
+        }
+
+        // Serde itself refuses to serialize the instants before the Unix epoch
+        let before_epoch = Wrapper {
+            created_at: UNIX_EPOCH - Duration::from_secs(1),
+        };
+        assert!(firestore_document_from_serializable("test/doc-id", &before_epoch).is_err());
+
+        // And reading one back reports a descriptive error instead of overflowing
+        let document = Document {
+            name: "test/doc-id".to_string(),
+            fields: vec![(
+                "created_at".to_string(),
+                Value {
+                    value_type: Some(ValueType::TimestampValue(
+                        gcloud_sdk::prost_types::Timestamp {
+                            seconds: -1,
+                            nanos: 0,
+                        },
+                    )),
+                },
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        assert!(firestore_document_to_serializable::<Wrapper>(&document).is_err());
+    }
+}

--- a/src/firestore_serde/system_time_serializers.rs
+++ b/src/firestore_serde/system_time_serializers.rs
@@ -6,9 +6,8 @@
 //! Firestore timestamp instead, so a plain `SystemTime` field needs neither an
 //! attribute nor a wrapping type.
 //!
-//! Reading is deliberately lenient: a native timestamp is preferred, but the two
-//! field map written by the earlier versions of this library is still accepted,
-//! so the existing documents keep working without a migration.
+//! Only the shape serde produces is recognised, so a user defined structure that
+//! merely shares the name keeps serializing as an ordinary map.
 
 use std::collections::HashMap;
 
@@ -139,9 +138,8 @@ pub(crate) fn timestamp_to_system_time_parts(
 mod tests {
     use crate::{firestore_document_from_serializable, firestore_document_to_serializable};
     use gcloud_sdk::google::firestore::v1::value::ValueType;
-    use gcloud_sdk::google::firestore::v1::{Document, MapValue, Value};
+    use gcloud_sdk::google::firestore::v1::{Document, Value};
     use serde::{Deserialize, Serialize};
-    use std::collections::HashMap;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -217,54 +215,6 @@ mod tests {
         let deserialized: TestStructure =
             firestore_document_to_serializable(&document).expect("Unable to deserialize");
         assert_eq!(deserialized, test_structure);
-    }
-
-    #[test]
-    fn test_legacy_system_time_map_still_deserializes() {
-        // The documents written by the earlier versions carry the two field map
-        // serde produces by default, and must keep working without a migration.
-        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-        struct LegacyStructure {
-            created_at: SystemTime,
-            updated_at: Option<SystemTime>,
-        }
-
-        let legacy_fields: HashMap<String, Value> = vec![
-            (
-                "secs_since_epoch".to_string(),
-                Value {
-                    value_type: Some(ValueType::IntegerValue(1_670_000_000)),
-                },
-            ),
-            (
-                "nanos_since_epoch".to_string(),
-                Value {
-                    value_type: Some(ValueType::IntegerValue(123_456_789)),
-                },
-            ),
-        ]
-        .into_iter()
-        .collect();
-
-        let document = Document {
-            name: "test/doc-id".to_string(),
-            fields: vec![(
-                "created_at".to_string(),
-                Value {
-                    value_type: Some(ValueType::MapValue(MapValue {
-                        fields: legacy_fields,
-                    })),
-                },
-            )]
-            .into_iter()
-            .collect(),
-            ..Default::default()
-        };
-
-        let deserialized: LegacyStructure =
-            firestore_document_to_serializable(&document).expect("Unable to deserialize");
-        assert_eq!(deserialized.created_at, sample_time());
-        assert_eq!(deserialized.updated_at, None);
     }
 
     #[test]

--- a/src/firestore_serde/timestamp_serializers.rs
+++ b/src/firestore_serde/timestamp_serializers.rs
@@ -499,7 +499,7 @@ mod tests {
         );
     }
 
-    /// Mirrors the structure used by `examples/timestamp.rs`, so that all three
+    /// Mirrors the structure used by `examples/timestamp.rs`, so that all the
     /// documented ways of writing a Firestore timestamp stay verified.
     #[test]
     fn test_all_documented_timestamp_forms() {
@@ -509,6 +509,7 @@ mod tests {
         #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
         struct ExampleStructure {
             some_id: String,
+            created_at_system_time: std::time::SystemTime,
             created_at: FirestoreTimestamp,
             updated_at: Option<FirestoreTimestamp>,
             updated_at_always_none: Option<FirestoreTimestamp>,
@@ -526,6 +527,7 @@ mod tests {
 
         let example = ExampleStructure {
             some_id: "test-1".to_string(),
+            created_at_system_time: std::time::SystemTime::now(),
             created_at: FirestoreTimestamp::now(),
             updated_at: Some(from_system_time),
             updated_at_always_none: None,


### PR DESCRIPTION
Serde models `std::time::SystemTime` as a two field structure, so until now such a field was stored as a Firestore map:

```
created_at: { secs_since_epoch: 1670000000, nanos_since_epoch: 123456789 }
```

which cannot be range queried and does not read as a time.

The serializer and the deserializer now recognise that shape and map it to a native Firestore timestamp, so a plain `SystemTime` field needs neither an attribute nor a wrapping type:

```rust
#[derive(Debug, Clone, Deserialize, Serialize)]
struct MyTestStructure {
    created_at: SystemTime,
    updated_at: Option<SystemTime>,
}
```

`Option`, `Vec` and the nested structures are covered as well, since the serializer already recurses per field.

### Compatibility

This **changes the representation of the newly written documents**. Anything outside of this library that reads them, such as a query on `secs_since_epoch` or a client in another language, will see a timestamp instead of a map.

Storing a `SystemTime` as a map was not useful, so it is unlikely anyone relied on it. Such documents still deserialize, since that is simply the default path, but it is not a documented guarantee.

Only the shape serde produces is folded, so a user defined structure that merely shares the name keeps serializing as an ordinary map.

`SystemTime` still cannot carry the instants before the Unix epoch, since serde itself refuses them on serialization. Reading such a timestamp now reports a descriptive error pointing at `FirestoreTimestamp` instead of overflowing.

### Testing

Unit tests cover the round trip including `Option`, `Vec` and nesting, that a structure merely named `SystemTime` is not intercepted, and the pre epoch handling in both directions.

Verified end to end against a Firestore emulator, where the stored document contains:

```json
"created_at_system_time": { "timestampValue": "2026-08-20T18:26:31.284785Z" }
```

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -Dwarnings`, 30 lib tests and 17 doctests pass.
