### PR TITLE
feat: Act on listener target lifecycle and make cached collections dynamic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,4 +101,4 @@ required-features = ["caching-memory"]
 [[test]]
 name = "caching_watched_documents_test"
 path = "tests/caching_watched_documents_test.rs"
-required-features = ["caching-memory"]
+required-features = ["caching-memory", "caching-persistent"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,11 @@ path = "examples/caching_memory_collections.rs"
 required-features = ["caching-memory"]
 
 [[example]]
+name = "caching_dynamic_collections"
+path = "examples/caching_dynamic_collections.rs"
+required-features = ["caching-memory"]
+
+[[example]]
 name = "caching_persistent_collections"
 path = "examples/caching_persistent_collections.rs"
 required-features = ["caching-persistent"]
@@ -82,3 +87,13 @@ required-features = ["caching-memory"]
 name = "caching_persistent_test"
 path = "tests/caching_persistent_test.rs"
 required-features = ["caching-persistent"]
+
+[[test]]
+name = "caching_resume_token_test"
+path = "tests/caching_resume_token_test.rs"
+required-features = ["caching-persistent"]
+
+[[test]]
+name = "caching_dynamic_collections_test"
+path = "tests/caching_dynamic_collections_test.rs"
+required-features = ["caching-memory"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,3 +97,8 @@ required-features = ["caching-persistent"]
 name = "caching_dynamic_collections_test"
 path = "tests/caching_dynamic_collections_test.rs"
 required-features = ["caching-memory"]
+
+[[test]]
+name = "caching_watched_documents_test"
+path = "tests/caching_watched_documents_test.rs"
+required-features = ["caching-memory"]

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -200,3 +200,19 @@ FirestoreCache::memory(&db)
 constructing that struct with a literal needs the extra field - use
 `FirestoreCacheCollectionConfiguration::new(..)` and the `with_documents` builder instead. Such a
 collection is never listable, whatever its load mode.
+
+### Detecting a diverged cache
+
+The cache now acts on Firestore's existence filter, which reports how many documents a target
+matches. When that disagrees with what a preloaded collection holds - meaning changes were missed,
+typically deletes that happened while the listener was disconnected - the collection is dropped and
+replayed rather than left quietly wrong.
+
+The count is only compared when it can be trusted. A collection filled lazily, or held in a memory
+cache configured with `time_to_live` / `time_to_idle`, is never checked this way: a shortfall there
+is the cache expiring entries rather than a divergence, and treating it as one would re-download
+the collection repeatedly.
+
+`FirestoreCacheBackend` gains `authoritative_doc_count` and `begin_collection_resync` for this, both
+with default implementations - the first disables the check, the second falls back to invalidating
+the whole cache. Custom backends keep compiling; implement them to get the finer behaviour.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -185,3 +185,18 @@ directory without waiting for the first to be dropped.
 
 Reads through a cache that has been shut down do not fail: they behave as a cache miss, so
 `read_through_cache` falls back to Firestore and `read_cached_only` reports the miss as an error.
+
+### Caching named documents
+
+A cached collection can now be limited to a set of document IDs, which makes the listener watch
+exactly those documents instead of the whole collection:
+
+```rust
+FirestoreCache::memory(&db)
+    .collection_with("configs", |c| c.documents(["site", "billing"]).preload_all())
+```
+
+`FirestoreCacheCollectionConfiguration` gains a `collection_watch` field for this, so any code
+constructing that struct with a literal needs the extra field - use
+`FirestoreCacheCollectionConfiguration::new(..)` and the `with_documents` builder instead. Such a
+collection is never listable, whatever its load mode.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -56,9 +56,9 @@ relied on the old behaviour.
 | `db.aggregated_query_obj::<T>(params)` | `db.fluent().select().from(C).aggregate(...).obj::<T>().query()` |
 | `db.listen_doc_changes(...)` | `db.fluent().select().from(C).listen().add_target(target_id, &mut listener)?` |
 
-Unchanged in 0.52: batch writers, transactions, `db.create_listener()`,
-`FirestoreResumeStateStorage`, the cache backend traits and the
-`FirestoreDb::serialize_*_to_doc` / `deserialize_doc_to` helpers.
+Unchanged in 0.52: batch writers, transactions, `db.create_listener()` and the
+`FirestoreDb::serialize_*_to_doc` / `deserialize_doc_to` helpers. `FirestoreResumeStateStorage`
+gains one method with a default implementation - see [Listener changes](#listener-changes).
 
 `FirestoreTransactionOps` also stays public. It is implemented by both `FirestoreTransaction` and
 `FirestoreTransactionData`, so you can keep writing transaction-agnostic abstractions over it.
@@ -110,3 +110,78 @@ Two behaviour changes to be aware of:
 
 The persistent cache also had a bug where document deletions were never committed, so deleted
 documents stayed cached indefinitely. If you use `caching-persistent`, upgrading is recommended.
+
+### Listener changes
+
+The listener now acts on the target-lifecycle messages it previously ignored. Three things change
+for callers.
+
+`FirestoreResumeStateStorage` gains `forget_resume_state`, with a default implementation that does
+nothing, so existing implementations keep compiling. Implement it if your storage is durable: it is
+called when Firestore reports that it reset or removed a target, and a token kept past that point
+is read back on the next process start and rejected. Both shipped storages implement it.
+
+Listener callbacks now receive `TargetChange` events that carried a resume token. Previously the
+listener consumed those itself and never passed them on, so a `RESET` or a `REMOVE` was invisible.
+Callbacks that only match `DocumentChange` are unaffected; a callback with a catch-all arm will see
+more events than before. Match on them with the new `FirestoreListenerTargetChangeType` alias:
+
+```rust
+if let FirestoreListenEvent::TargetChange(target_change) = event {
+    if FirestoreListenerTargetChangeType::try_from(target_change.target_change_type)
+        == Ok(FirestoreListenerTargetChangeType::Current)
+    {
+        // The target now reflects a consistent snapshot.
+    }
+}
+```
+
+A listen request Firestore rejects as invalid no longer shuts the whole listener down on the first
+attempt. Because a stale resume token is a plausible cause, and one bad token used to take down
+every target, the listener now discards all stored resume tokens and retries once before treating
+the error as permanent.
+
+### Caching changes from the listener work
+
+The cache now removes a document when Firestore reports it as removed rather than deleted
+(`DocumentRemove`), which it previously dropped on the floor - such a document stayed cached
+indefinitely. It also acts on target resets: it drops what it holds for the affected collection and
+lets Firestore replay it. While that replay is in progress the collection does not answer
+`list`/`query` from the cache, so `read_through_cache` falls back to Firestore and
+`read_cached_only` returns a `FirestoreError::CacheError` for the duration.
+
+### Changing cached collections at runtime
+
+Collections can now be added to and removed from a running cache, so the set of cached collections
+no longer has to be decided when the cache is built:
+
+```rust
+cache.add_collection(FirestoreCacheCollection::new("currencies").preload_all()).await?;
+cache.remove_collection("currencies").await?;
+```
+
+Three things changed to make this possible.
+
+`FirestoreListener::add_target` now takes `&self` instead of `&mut self`, and works after `start()`
+as well as before it. Calling it through a `&mut` binding still compiles, so the fluent
+`.listen().add_target(target_id, &mut listener)` form is unaffected. It now rejects a target ID that
+is already registered, where it previously accepted the duplicate and silently collapsed it. There
+is also a new `remove_target`, which is `async` because it forgets the target's stored resume state
+before returning.
+
+`FirestoreCacheBackend` gains `cache_configuration`, `add_collection` and `remove_collection`. All
+three have default implementations - the last two report that the backend does not support the
+operation - so existing backends keep compiling. The `config` field on both shipped backends is now
+private; use the `config()` accessor instead.
+
+A cache may now be built with no collections at all, where the builder previously rejected that.
+
+### Shutdown releases resources
+
+`FirestoreCache::shutdown` now releases the backend's resources rather than only stopping the
+listener. The in-memory backend drops its cached documents; the persistent backend closes its
+database, releasing the exclusive lock on the file so another cache can be opened over the same
+directory without waiting for the first to be dropped.
+
+Reads through a cache that has been shut down do not fail: they behave as a cache miss, so
+`read_through_cache` falls back to Firestore and `read_cached_only` reports the miss as an error.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -58,7 +58,7 @@ relied on the old behaviour.
 
 Unchanged in 0.52: batch writers, transactions, `db.create_listener()` and the
 `FirestoreDb::serialize_*_to_doc` / `deserialize_doc_to` helpers. `FirestoreResumeStateStorage`
-gains one method with a default implementation - see [Listener changes](#listener-changes).
+gains one required method - see [Listener changes](#listener-changes).
 
 `FirestoreTransactionOps` also stays public. It is implemented by both `FirestoreTransaction` and
 `FirestoreTransactionData`, so you can keep writing transaction-agnostic abstractions over it.
@@ -116,10 +116,21 @@ documents stayed cached indefinitely. If you use `caching-persistent`, upgrading
 The listener now acts on the target-lifecycle messages it previously ignored. Three things change
 for callers.
 
-`FirestoreResumeStateStorage` gains `forget_resume_state`, with a default implementation that does
-nothing, so existing implementations keep compiling. Implement it if your storage is durable: it is
-called when Firestore reports that it reset or removed a target, and a token kept past that point
-is read back on the next process start and rejected. Both shipped storages implement it.
+`FirestoreResumeStateStorage` gains a required `forget_resume_state`, so a custom implementation
+will not compile until it is added. That is deliberate: it is called when Firestore resets or
+removes a target, and a durable storage that quietly kept the token would hand it back on the next
+process start, where Firestore rejects it with `INVALID_ARGUMENT`. For most storages it is a
+one-liner - dropping the entry, as the in-memory one does:
+
+```rust
+async fn forget_resume_state(&self, target: &FirestoreListenerTarget) -> AnyBoxedErrResult<()> {
+    self.tokens.write().await.remove(target);
+    Ok(())
+}
+```
+
+A storage that holds nothing across restarts may return `Ok(())` and do nothing. Both shipped
+storages implement it.
 
 Listener callbacks now receive `TargetChange` events that carried a resume token. Previously the
 listener consumed those itself and never passed them on, so a `RESET` or a `REMOVE` was invisible.

--- a/README.md
+++ b/README.md
@@ -841,6 +841,30 @@ Because `load` and `shutdown` take `&self`, a built cache can be shared directly
 `Arc<FirestoreMemoryCache>` in your application state. `FirestoreMemoryCache` and
 `FirestorePersistentCache` are aliases that save you from spelling out the generic parameters.
 
+`shutdown` stops the listener and releases the backend's resources: the in-memory cache drops its
+documents, and the persistent cache closes its database file, so another cache can be opened over
+the same directory.
+
+### Changing the cached collections at runtime
+
+The set of cached collections does not have to be fixed when the cache is built:
+
+```rust
+cache.add_collection(FirestoreCacheCollection::new("currencies").preload_all()).await?;
+
+cache.remove_collection("currencies").await?;
+```
+
+`add_collection` downloads the collection first if it is preloaded, publishes it only once it is
+complete, and then extends the listener - so a listing never observes it half filled, and nothing
+written during the download is missed. `remove_collection` does the reverse, and also forgets the
+collection's resume token so its listener target ID cannot be reused against a different query.
+Use `remove_collection_at` for a sub-collection, whose absolute path a bare name cannot address.
+
+`FirestoreDb` handles created earlier with `read_through_cache` or `read_cached_only` pick both up
+immediately: they share the cache's backend rather than a copy of it. A cache can also be built
+with no collections at all and populated entirely at runtime.
+
 ### Choosing a cache mode
 
 - `db.read_through_cache(&cache)` serves what it can from the cache and goes to Firestore for the
@@ -883,9 +907,14 @@ acceptable, opt in with
   your application or from elsewhere;
 - Preloading at startup.
 
-Cached results are eventually consistent: they reflect the last state the listener delivered. A
-write may take a moment to show up, and a stalled or reset listener can leave the cache stale
-without saying so. Do not cache data that must be read at strong consistency.
+Cached results are eventually consistent: they reflect the last state the listener delivered, so a
+write may take a moment to show up. Do not cache data that must be read at strong consistency.
+
+When Firestore resets or removes a listener target - after a reconnect, or when a stored resume
+token has expired - the cache drops what it holds for that collection and Firestore replays it.
+While that replay is in progress the collection stops answering `list` and `query` from the cache:
+`read_through_cache` falls back to Firestore, and `read_cached_only` returns a `CacheError` rather
+than a listing that looks complete but is not.
 
 Full examples are available [here](examples/caching_memory_collections.rs)
 and [here](examples/caching_persistent_collections.rs).

--- a/README.md
+++ b/README.md
@@ -845,6 +845,26 @@ Because `load` and `shutdown` take `&self`, a built cache can be shared directly
 documents, and the persistent cache closes its database file, so another cache can be opened over
 the same directory.
 
+### Caching named documents instead of a whole collection
+
+`.collection(name)` subscribes the listener to the **entire** collection, even though it does not
+preload it - "lazy" only means the initial download is skipped. When you know which documents you
+care about, say so:
+
+```rust
+let cache = FirestoreCache::memory(&db)
+    .collection_with("configs", |c| c.documents(["site", "billing"]).preload_all())
+    .build()
+    .await?;
+```
+
+The listener then watches exactly those documents, so unrelated changes in the collection are never
+streamed to your process or written into the cache, and preloading reads just those IDs. This is
+the shape to reach for with configuration, feature flags and reference data.
+
+Such a collection is never listable, whatever its load mode: it holds a chosen subset, so `list`
+and `query` would return a partial answer that looks complete.
+
 ### Changing the cached collections at runtime
 
 The set of cached collections does not have to be fixed when the cache is built:

--- a/README.md
+++ b/README.md
@@ -930,6 +930,12 @@ acceptable, opt in with
 Cached results are eventually consistent: they reflect the last state the listener delivered, so a
 write may take a moment to show up. Do not cache data that must be read at strong consistency.
 
+Firestore also reports how many documents a target matches. When that disagrees with what a
+preloaded collection holds - which means changes were missed, typically deletes that happened while
+the listener was disconnected - the cache drops the collection and has Firestore replay it. The
+count is only compared when it can be trusted: a collection the cache expires entries from, or
+fills lazily, is never checked this way.
+
 When Firestore resets or removes a listener target - after a reconnect, or when a stored resume
 token has expired - the cache drops what it holds for that collection and Firestore replays it.
 While that replay is in progress the collection stops answering `list` and `query` from the cache:

--- a/examples/caching_dynamic_collections.rs
+++ b/examples/caching_dynamic_collections.rs
@@ -1,0 +1,127 @@
+use firestore::*;
+use futures::TryStreamExt;
+use serde::{Deserialize, Serialize};
+
+pub fn config_env_var(name: &str) -> Result<String, String> {
+    std::env::var(name).map_err(|e| format!("{name}: {e}"))
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct MyTestStructure {
+    some_id: String,
+    some_string: String,
+}
+
+const FIRST_COLLECTION: &str = "test-caching-dynamic-first";
+const SECOND_COLLECTION: &str = "test-caching-dynamic-second";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter("firestore=debug")
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    let db = FirestoreDb::new(&config_env_var("PROJECT_ID")?).await?;
+
+    for collection in [FIRST_COLLECTION, SECOND_COLLECTION] {
+        populate(&db, collection).await?;
+    }
+
+    // Build the cache knowing about one collection only.
+    let cache = FirestoreCache::memory(&db)
+        .name("example-dynamic-cache")
+        .preloaded_collection(FIRST_COLLECTION)
+        .build()
+        .await?;
+
+    // Derived before the second collection exists in the cache. It shares the cache's backend
+    // rather than a copy, so it will see the addition without being recreated.
+    let cached_db = db.read_cached_only(&cache);
+
+    println!("Cached collections: {:?}", cache.cached_collections());
+
+    // Not cached yet, so a cache-only listing refuses rather than returning an empty result that
+    // would look like a complete one.
+    match list(&cached_db, SECOND_COLLECTION).await {
+        Ok(docs) => println!("Unexpectedly listed {} documents", docs.len()),
+        Err(err) => println!("Not cached yet, as expected: {err}"),
+    }
+
+    // Add it at runtime: it is downloaded, published once complete, and the listener extended.
+    cache
+        .add_collection(FirestoreCacheCollection::new(SECOND_COLLECTION).preload_all())
+        .await?;
+
+    println!("Cached collections: {:?}", cache.cached_collections());
+    println!(
+        "Listing {SECOND_COLLECTION} from cache: {} documents",
+        list(&cached_db, SECOND_COLLECTION).await?.len()
+    );
+
+    // Stop caching it again: the documents are dropped and the listener stops watching it.
+    cache.remove_collection(SECOND_COLLECTION).await?;
+
+    println!("Cached collections: {:?}", cache.cached_collections());
+    match list(&cached_db, SECOND_COLLECTION).await {
+        Ok(docs) => println!("Unexpectedly listed {} documents", docs.len()),
+        Err(err) => println!("No longer cached, as expected: {err}"),
+    }
+
+    // The other collection is untouched throughout.
+    println!(
+        "Listing {FIRST_COLLECTION} from cache: {} documents",
+        list(&cached_db, FIRST_COLLECTION).await?.len()
+    );
+
+    cache.shutdown().await?;
+    Ok(())
+}
+
+async fn list(db: &FirestoreDb, collection: &str) -> FirestoreResult<Vec<MyTestStructure>> {
+    db.fluent()
+        .list()
+        .from(collection)
+        .obj::<MyTestStructure>()
+        .stream_all_with_errors()
+        .await?
+        .try_collect()
+        .await
+}
+
+async fn populate(
+    db: &FirestoreDb,
+    collection: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if db
+        .fluent()
+        .select()
+        .by_id_in(collection)
+        .one("test-0")
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    println!("Populating {collection}");
+    let batch_writer = db.create_simple_batch_writer().await?;
+    let mut current_batch = batch_writer.new_batch();
+
+    for i in 0..5 {
+        let my_struct = MyTestStructure {
+            some_id: format!("test-{i}"),
+            some_string: format!("Test value {i}"),
+        };
+
+        db.fluent()
+            .update()
+            .in_col(collection)
+            .document_id(&my_struct.some_id)
+            .object(&my_struct)
+            .add_to_batch(&mut current_batch)?;
+    }
+    current_batch.write().await?;
+
+    Ok(())
+}

--- a/examples/caching_dynamic_collections.rs
+++ b/examples/caching_dynamic_collections.rs
@@ -74,7 +74,74 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         list(&cached_db, FIRST_COLLECTION).await?.len()
     );
 
+    // ---------------------------------------------------------------------------------------
+    // Tracking individual documents, and changing which ones are tracked
+    // ---------------------------------------------------------------------------------------
+
+    // Caching a known set of documents - configuration, feature flags, reference data - is worth
+    // saying explicitly: the listener then watches exactly these documents, so unrelated changes
+    // in the collection are never streamed here.
+    let mut tracked = vec!["test-0".to_string(), "test-1".to_string()];
+    track_documents(&cache, &tracked).await?;
+    report_tracked(&cached_db, &["test-0", "test-1", "test-2"]).await?;
+
+    // Start tracking one more document and stop tracking another. A Firestore documents target
+    // carries a fixed list, so changing it means replacing the target: keep the set on your side
+    // and re-apply it, rather than trying to edit it in place.
+    tracked.push("test-2".to_string());
+    tracked.retain(|id| id != "test-0");
+    track_documents(&cache, &tracked).await?;
+    report_tracked(&cached_db, &["test-0", "test-1", "test-2"]).await?;
+
     cache.shutdown().await?;
+    Ok(())
+}
+
+/// Caches exactly `document_ids` of the tracked collection, replacing whatever was tracked before.
+async fn track_documents(
+    cache: &FirestoreMemoryCache,
+    document_ids: &[String],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    println!("\nTracking documents: {document_ids:?}");
+
+    // Removing first because a collection can only be cached once, and the watched set is part of
+    // its listener target rather than something that can be edited afterwards.
+    cache.remove_collection(SECOND_COLLECTION).await?;
+
+    cache
+        .add_collection(
+            FirestoreCacheCollection::new(SECOND_COLLECTION)
+                .documents(document_ids)
+                .preload_all(),
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Prints which of `document_ids` the cache holds, without falling back to Firestore.
+async fn report_tracked(
+    cached_db: &FirestoreDb,
+    document_ids: &[&str],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    for document_id in document_ids {
+        let found: Option<MyTestStructure> = cached_db
+            .fluent()
+            .select()
+            .by_id_in(SECOND_COLLECTION)
+            .obj()
+            .one(*document_id)
+            .await?;
+
+        println!(
+            "  {document_id}: {}",
+            if found.is_some() {
+                "cached"
+            } else {
+                "not cached"
+            }
+        );
+    }
     Ok(())
 }
 

--- a/examples/listen-changes.rs
+++ b/examples/listen-changes.rs
@@ -84,6 +84,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         println!("As object: {obj:?}");
                     }
                 }
+                // The document went out of view of the target - deleted, or no longer readable.
+                FirestoreListenEvent::DocumentDelete(ref deleted) => {
+                    println!("Doc deleted: {:?}", deleted.document);
+                }
+                FirestoreListenEvent::DocumentRemove(ref removed) => {
+                    println!("Doc removed from the target: {:?}", removed.document);
+                }
+                // Target lifecycle. `Current` means the target now reflects a consistent
+                // snapshot, and `Remove` means Firestore dropped it - `cause` says why.
+                FirestoreListenEvent::TargetChange(ref target_change) => {
+                    match FirestoreListenerTargetChangeType::try_from(
+                        target_change.target_change_type,
+                    ) {
+                        Ok(FirestoreListenerTargetChangeType::Current) => {
+                            println!("Targets are up to date: {:?}", target_change.target_ids);
+                        }
+                        Ok(FirestoreListenerTargetChangeType::Remove) => {
+                            println!(
+                                "Targets {:?} were removed by Firestore: {:?}",
+                                target_change.target_ids, target_change.cause
+                            );
+                        }
+                        Ok(FirestoreListenerTargetChangeType::Reset) => {
+                            println!(
+                                "Targets {:?} were reset and will be resent",
+                                target_change.target_ids
+                            );
+                        }
+                        _ => {}
+                    }
+                }
                 _ => {
                     println!("Received a listen response event to handle: {event:?}");
                 }

--- a/src/cache/backends/memory_backend.rs
+++ b/src/cache/backends/memory_backend.rs
@@ -1,5 +1,4 @@
 use crate::errors::*;
-use crate::FirestoreInstant;
 use crate::*;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
@@ -382,7 +381,7 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
         _options: &FirestoreCacheOptions,
         db: &FirestoreDb,
     ) -> Result<Vec<FirestoreListenerTargetParams>, FirestoreError> {
-        let read_from_time = FirestoreInstant::now();
+        let read_from_time = crate::cache::cache_target_read_time();
 
         self.preload_collections(db).await?;
 
@@ -420,7 +419,7 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
     ) -> FirestoreResult<FirestoreListenerTargetParams> {
         // Captured before reading anything, so that writes landing during the preload are still
         // delivered once the listener target attaches from this point in time.
-        let read_from_time = FirestoreInstant::now();
+        let read_from_time = crate::cache::cache_target_read_time();
         let collection_path = collection_config.resolve_collection_path(db.get_documents_path());
 
         let mem_cache = (self.collection_mem_options)(collection_path.as_str()).build();

--- a/src/cache/backends/memory_backend.rs
+++ b/src/cache/backends/memory_backend.rs
@@ -247,6 +247,35 @@ impl FirestoreMemoryCacheBackend {
     ) -> Result<(), FirestoreError> {
         debug!(collection_path, "Preloading collection.");
 
+        // A collection watched by document ID is preloaded by reading exactly those documents,
+        // rather than downloading the collection and throwing most of it away.
+        if let Some(document_ids) = config.watched_document_ids() {
+            let selector = db
+                .fluent()
+                .select()
+                .by_id_in(config.collection_name.as_str());
+            let selector = match &config.parent {
+                Some(parent) => selector.parent(parent),
+                None => selector,
+            };
+
+            let mut stream = selector.batch(document_ids.to_vec()).await?;
+            while let Some((_, doc)) = stream.next().await {
+                if let Some(doc) = doc {
+                    let (_, document_id) = split_document_path(&doc.name);
+                    mem_cache.insert(document_id.to_string(), doc).await;
+                }
+            }
+
+            mem_cache.run_pending_tasks().await;
+            info!(
+                collection_path,
+                entry_count = mem_cache.entry_count(),
+                "Preloading watched documents has been finished.",
+            );
+            return Ok(());
+        }
+
         let params = if let Some(parent) = &config.parent {
             db.fluent()
                 .select()
@@ -282,54 +311,12 @@ impl FirestoreMemoryCacheBackend {
     async fn preload_collections(&self, db: &FirestoreDb) -> Result<(), FirestoreError> {
         let config_snapshot = self.config();
         for (collection_path, config) in &config_snapshot.collections {
-            match config.collection_load_mode {
-                FirestoreCacheCollectionLoadMode::PreloadAllDocs
-                | FirestoreCacheCollectionLoadMode::PreloadAllIfEmpty => {
-                    if let Some(mem_cache) = self.collection_cache(collection_path.as_str()) {
-                        debug!(collection_path, "Preloading collection.");
-
-                        let params = if let Some(parent) = &config.parent {
-                            db.fluent()
-                                .select()
-                                .from(config.collection_name.as_str())
-                                .parent(parent)
-                        } else {
-                            db.fluent().select().from(config.collection_name.as_str())
-                        };
-
-                        let stream = params.stream_query().await?;
-
-                        stream
-                            .enumerate()
-                            .map(|(index, docs)| {
-                                if index > 0 && index % 5000 == 0 {
-                                    debug!(
-                                        collection_path = collection_path.as_str(),
-                                        entries_loaded = index,
-                                        "Collection preload in progress...",
-                                    );
-                                }
-                                docs
-                            })
-                            .for_each_concurrent(1, |doc| {
-                                let mem_cache = mem_cache.clone();
-                                async move {
-                                    let (_, document_id) = split_document_path(&doc.name);
-                                    mem_cache.insert(document_id.to_string(), doc).await;
-                                }
-                            })
-                            .await;
-
-                        mem_cache.run_pending_tasks().await;
-
-                        info!(
-                            collection_path = collection_path.as_str(),
-                            entry_count = mem_cache.entry_count(),
-                            "Preloading collection has been finished.",
-                        );
-                    }
-                }
-                FirestoreCacheCollectionLoadMode::PreloadNone => {}
+            if !config.collection_load_mode.is_preloading() {
+                continue;
+            }
+            if let Some(mem_cache) = self.collection_cache(collection_path.as_str()) {
+                self.preload_one_collection(db, collection_path, config, &mem_cache)
+                    .await?;
             }
         }
         Ok(())
@@ -509,6 +496,12 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
             FirestoreListenEvent::DocumentChange(doc_change) => {
                 if let Some(doc) = doc_change.document {
                     let (collection_path, document_id) = split_document_path(&doc.name);
+                    if !self
+                        .config()
+                        .is_document_cached(collection_path, document_id)
+                    {
+                        return Ok(());
+                    }
                     if let Some(mem_cache) = self.collection_cache(collection_path) {
                         trace!(
                             doc_name = ?doc.name,
@@ -532,16 +525,37 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
             }
             FirestoreListenEvent::TargetChange(ref target_change) => {
                 match crate::cache::cache_target_change_action(&self.config(), target_change) {
-                    crate::cache::FirestoreCacheTargetChangeAction::SuspendAndInvalidate(paths) => {
+                    crate::cache::FirestoreCacheTargetChangeAction::SuspendAndInvalidate(
+                        invalidations,
+                    ) => {
                         {
                             let mut suspended = self
                                 .suspended_collections
                                 .write()
                                 .expect("cache suspended collections lock poisoned");
-                            suspended.extend(paths.iter().cloned());
+                            suspended.extend(
+                                invalidations
+                                    .iter()
+                                    .map(|invalidation| invalidation.collection_path().to_string()),
+                            );
                         }
-                        for collection_path in &paths {
-                            self.invalidate_collection(collection_path).await;
+                        for invalidation in &invalidations {
+                            match invalidation {
+                                crate::cache::FirestoreCacheInvalidation::Collection(
+                                    collection_path,
+                                ) => self.invalidate_collection(collection_path).await,
+                                crate::cache::FirestoreCacheInvalidation::Documents {
+                                    collection_path,
+                                    document_ids,
+                                } => {
+                                    if let Some(mem_cache) = self.collection_cache(collection_path)
+                                    {
+                                        for document_id in document_ids {
+                                            mem_cache.remove(document_id).await;
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                     crate::cache::FirestoreCacheTargetChangeAction::Resume(paths) => {
@@ -581,6 +595,13 @@ impl FirestoreCacheDocsByPathSupport for FirestoreMemoryCacheBackend {
 
     async fn update_doc_by_path(&self, document: &FirestoreDocument) -> FirestoreResult<()> {
         let (collection_path, document_id) = split_document_path(&document.name);
+
+        if !self
+            .config()
+            .is_document_cached(collection_path, document_id)
+        {
+            return Ok(());
+        }
 
         match self.collection_cache(collection_path) {
             Some(mem_cache) => {
@@ -687,14 +708,22 @@ mod tests {
         format!("{DOCS}/{collection}/{id}")
     }
 
+    /// Writes straight into the collection's cache, bypassing the watch filter, so that tests can
+    /// set up documents a target does not cover.
     async fn seed(backend: &FirestoreMemoryCacheBackend, collection: &str, id: &str) {
-        backend
-            .update_doc_by_path(&FirestoreDocument {
-                name: doc_path(collection, id),
-                ..Default::default()
-            })
-            .await
-            .expect("seeded document");
+        let collection_path = format!("{DOCS}/{collection}");
+        let mem_cache = backend
+            .collection_cache(&collection_path)
+            .expect("configured collection");
+        mem_cache
+            .insert(
+                id.to_string(),
+                FirestoreDocument {
+                    name: doc_path(collection, id),
+                    ..Default::default()
+                },
+            )
+            .await;
     }
 
     async fn cached(backend: &FirestoreMemoryCacheBackend, collection: &str, id: &str) -> bool {
@@ -823,6 +852,74 @@ mod tests {
         assert!(!cached(&backend, "b", "one").await);
         assert!(!is_listable(&backend, "a").await);
         assert!(!is_listable(&backend, "b").await);
+    }
+
+    fn watched(collections: &[(&str, u32, &[&str])]) -> FirestoreMemoryCacheBackend {
+        let config = collections.iter().fold(
+            FirestoreCacheConfiguration::new(),
+            |config, (name, target, documents)| {
+                config.add_collection_config_at(
+                    DOCS,
+                    FirestoreCacheCollectionConfiguration::new(
+                        name,
+                        FirestoreListenerTarget::new(*target),
+                        FirestoreCacheCollectionLoadMode::PreloadAllDocs,
+                    )
+                    .with_documents(documents.iter()),
+                )
+            },
+        );
+
+        FirestoreMemoryCacheBackend::new(config).expect("backend")
+    }
+
+    #[tokio::test]
+    async fn a_documents_watch_is_never_listable_even_when_preloaded() {
+        let backend = watched(&[("a", 1000, &["one", "two"])]);
+
+        // It holds a chosen subset, so answering a listing would look complete but not be.
+        assert!(!is_listable(&backend, "a").await);
+    }
+
+    #[tokio::test]
+    async fn a_documents_watch_ignores_documents_outside_its_set() {
+        let backend = watched(&[("a", 1000, &["one"])]);
+
+        for document_id in ["one", "three"] {
+            backend
+                .on_listen_event(FirestoreListenEvent::DocumentChange(DocumentChange {
+                    document: Some(FirestoreDocument {
+                        name: doc_path("a", document_id),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }))
+                .await
+                .expect("event handled");
+        }
+
+        assert!(cached(&backend, "a", "one").await);
+        assert!(!cached(&backend, "a", "three").await);
+    }
+
+    #[tokio::test]
+    async fn resetting_a_documents_target_drops_only_the_watched_documents() {
+        let backend = watched(&[("a", 1000, &["one"])]);
+        seed(&backend, "a", "one").await;
+        // Present despite not being watched, as it would be if another target also covered this
+        // collection: the reset must not take it with it.
+        seed(&backend, "a", "other").await;
+
+        backend
+            .on_listen_event(target_change(
+                FirestoreListenerTargetChangeType::Reset,
+                vec![1000],
+            ))
+            .await
+            .expect("event handled");
+
+        assert!(!cached(&backend, "a", "one").await);
+        assert!(cached(&backend, "a", "other").await);
     }
 
     #[tokio::test]

--- a/src/cache/backends/memory_backend.rs
+++ b/src/cache/backends/memory_backend.rs
@@ -7,7 +7,8 @@ use moka::future::{Cache, CacheBuilder};
 
 use crate::cache::cache_query_engine::FirestoreCacheQueryEngine;
 use futures::StreamExt;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use tracing::*;
 
 #[doc(hidden)]
@@ -40,8 +41,17 @@ pub type FirestoreMemCacheOptions = CacheBuilder<String, FirestoreDocument, Fire
 /// # }
 /// ```
 pub struct FirestoreMemoryCacheBackend {
-    pub config: FirestoreCacheConfiguration,
-    collection_caches: HashMap<String, FirestoreMemCache>,
+    /// Behind a lock so that collections can be added and removed while the cache runs. Readers
+    /// clone the `Arc` out and drop the guard, so no guard is ever held across an await.
+    config: std::sync::RwLock<Arc<FirestoreCacheConfiguration>>,
+    collection_caches: std::sync::RwLock<Arc<HashMap<String, FirestoreMemCache>>>,
+    /// Retained so that a collection added at runtime gets a cache configured the same way as the
+    /// ones the backend was built with.
+    collection_mem_options: Box<dyn Fn(&str) -> FirestoreMemCacheOptions + Send + Sync>,
+    /// Collections whose listener target Firestore has reset or removed, and which are therefore
+    /// mid-replay. They must not answer `list`/`query` until the replay completes, because what
+    /// they hold in the meantime is a partial view that would look like a complete one.
+    suspended_collections: std::sync::RwLock<HashSet<String>>,
 }
 
 /// The maximum number of documents kept per collection unless configured otherwise.
@@ -149,9 +159,9 @@ impl FirestoreMemoryCacheBackend {
         collection_mem_options: FN,
     ) -> FirestoreResult<Self>
     where
-        FN: Fn(&str) -> FirestoreMemCacheOptions,
+        FN: Fn(&str) -> FirestoreMemCacheOptions + Send + Sync + 'static,
     {
-        let collection_caches = config
+        let collection_caches: HashMap<String, FirestoreMemCache> = config
             .collections
             .keys()
             .map(|collection_path| {
@@ -163,17 +173,119 @@ impl FirestoreMemoryCacheBackend {
             .collect();
 
         Ok(Self {
-            config,
-            collection_caches,
+            config: std::sync::RwLock::new(Arc::new(config)),
+            collection_caches: std::sync::RwLock::new(Arc::new(collection_caches)),
+            collection_mem_options: Box::new(collection_mem_options),
+            suspended_collections: std::sync::RwLock::new(HashSet::new()),
         })
     }
 
+    /// A snapshot of the collections this backend currently caches.
+    pub fn config(&self) -> Arc<FirestoreCacheConfiguration> {
+        self.config
+            .read()
+            .expect("cache configuration lock poisoned")
+            .clone()
+    }
+
+    /// The cache of one collection. `moka` caches are cheap to clone - they are reference counted
+    /// internally - so this hands out a handle rather than borrowing the map.
+    fn collection_cache(&self, collection_path: &str) -> Option<FirestoreMemCache> {
+        self.collection_caches
+            .read()
+            .expect("cache collections lock poisoned")
+            .get(collection_path)
+            .cloned()
+    }
+
+    fn all_collection_caches(&self) -> Arc<HashMap<String, FirestoreMemCache>> {
+        self.collection_caches
+            .read()
+            .expect("cache collections lock poisoned")
+            .clone()
+    }
+
+    /// Whether a collection is mid-replay after Firestore reset or removed its listener target.
+    fn is_suspended(&self, collection_path: &str) -> bool {
+        self.suspended_collections
+            .read()
+            .expect("cache suspended collections lock poisoned")
+            .contains(collection_path)
+    }
+
+    /// Drops everything cached for one collection.
+    async fn invalidate_collection(&self, collection_path: &str) {
+        if let Some(mem_cache) = self.collection_cache(collection_path) {
+            debug!(collection_path, "Invalidating cache for collection.");
+            mem_cache.invalidate_all();
+            mem_cache.run_pending_tasks().await;
+        }
+    }
+
+    /// Removes a document from the cache, wherever the listener said it went.
+    async fn evict_doc_by_path(&self, document_path: &str) {
+        let (collection_path, document_id) = split_document_path(document_path);
+        if let Some(mem_cache) = self.collection_cache(collection_path) {
+            trace!(
+                document_path,
+                "Removing document from cache due to listener event.",
+            );
+            mem_cache.remove(document_id).await;
+        }
+    }
+
+    /// Preloads one collection into a cache that is not published in the configuration yet.
+    ///
+    /// Keeping the publish until after the preload is what stops a half-filled collection from
+    /// answering a `list` as though it were complete.
+    async fn preload_one_collection(
+        &self,
+        db: &FirestoreDb,
+        collection_path: &str,
+        config: &FirestoreCacheCollectionConfiguration,
+        mem_cache: &FirestoreMemCache,
+    ) -> Result<(), FirestoreError> {
+        debug!(collection_path, "Preloading collection.");
+
+        let params = if let Some(parent) = &config.parent {
+            db.fluent()
+                .select()
+                .from(config.collection_name.as_str())
+                .parent(parent)
+        } else {
+            db.fluent().select().from(config.collection_name.as_str())
+        };
+
+        let stream = params.stream_query().await?;
+
+        stream
+            .for_each_concurrent(1, |doc| {
+                let mem_cache = mem_cache.clone();
+                async move {
+                    let (_, document_id) = split_document_path(&doc.name);
+                    mem_cache.insert(document_id.to_string(), doc).await;
+                }
+            })
+            .await;
+
+        mem_cache.run_pending_tasks().await;
+
+        info!(
+            collection_path,
+            entry_count = mem_cache.entry_count(),
+            "Preloading collection has been finished.",
+        );
+
+        Ok(())
+    }
+
     async fn preload_collections(&self, db: &FirestoreDb) -> Result<(), FirestoreError> {
-        for (collection_path, config) in &self.config.collections {
+        let config_snapshot = self.config();
+        for (collection_path, config) in &config_snapshot.collections {
             match config.collection_load_mode {
                 FirestoreCacheCollectionLoadMode::PreloadAllDocs
                 | FirestoreCacheCollectionLoadMode::PreloadAllIfEmpty => {
-                    if let Some(mem_cache) = self.collection_caches.get(collection_path.as_str()) {
+                    if let Some(mem_cache) = self.collection_cache(collection_path.as_str()) {
                         debug!(collection_path, "Preloading collection.");
 
                         let params = if let Some(parent) = &config.parent {
@@ -199,9 +311,12 @@ impl FirestoreMemoryCacheBackend {
                                 }
                                 docs
                             })
-                            .for_each_concurrent(1, |doc| async move {
-                                let (_, document_id) = split_document_path(&doc.name);
-                                mem_cache.insert(document_id.to_string(), doc).await;
+                            .for_each_concurrent(1, |doc| {
+                                let mem_cache = mem_cache.clone();
+                                async move {
+                                    let (_, document_id) = split_document_path(&doc.name);
+                                    mem_cache.insert(document_id.to_string(), doc).await;
+                                }
                             })
                             .await;
 
@@ -225,7 +340,7 @@ impl FirestoreMemoryCacheBackend {
         collection_path: &str,
         query_engine: FirestoreCacheQueryEngine,
     ) -> FirestoreResult<BoxStream<'b, FirestoreResult<FirestoreDocument>>> {
-        match self.collection_caches.get(collection_path) {
+        match self.collection_cache(collection_path) {
             Some(mem_cache) => {
                 let filtered_results: Vec<FirestoreResult<FirestoreDocument>> = mem_cache
                     .iter()
@@ -257,27 +372,20 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
         self.preload_collections(db).await?;
 
         Ok(self
-            .config
+            .config()
             .collections
             .values()
             .map(|collection_config| {
-                FirestoreListenerTargetParams::new(
-                    collection_config.listener_target.clone(),
-                    FirestoreTargetType::Query(
-                        FirestoreQueryParams::new(
-                            collection_config.collection_name.as_str().into(),
-                        )
-                        .opt_parent(collection_config.parent.clone()),
-                    ),
-                    HashMap::new(),
+                crate::cache::target_params_for_collection(
+                    collection_config,
+                    Some(FirestoreListenerTargetResumeType::ReadTime(read_from_time)),
                 )
-                .with_resume_type(FirestoreListenerTargetResumeType::ReadTime(read_from_time))
             })
             .collect())
     }
 
     async fn invalidate_all(&self) -> FirestoreResult<()> {
-        for (collection_path, mem_cache) in &self.collection_caches {
+        for (collection_path, mem_cache) in self.all_collection_caches().iter() {
             debug!(collection_path, "Invalidating cache for collection.");
             mem_cache.invalidate_all();
             mem_cache.run_pending_tasks().await;
@@ -285,8 +393,115 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
         Ok(())
     }
 
+    fn cache_configuration(&self) -> Arc<FirestoreCacheConfiguration> {
+        self.config()
+    }
+
+    async fn add_collection(
+        &self,
+        _options: &FirestoreCacheOptions,
+        db: &FirestoreDb,
+        collection_config: FirestoreCacheCollectionConfiguration,
+    ) -> FirestoreResult<FirestoreListenerTargetParams> {
+        // Captured before reading anything, so that writes landing during the preload are still
+        // delivered once the listener target attaches from this point in time.
+        let read_from_time = FirestoreInstant::now();
+        let collection_path = collection_config.resolve_collection_path(db.get_documents_path());
+
+        let mem_cache = (self.collection_mem_options)(collection_path.as_str()).build();
+
+        if collection_config.collection_load_mode.is_preloading() {
+            self.preload_one_collection(db, &collection_path, &collection_config, &mem_cache)
+                .await?;
+        }
+
+        // Published only now: until this point the collection does not exist as far as reads are
+        // concerned, so no listing can see it half filled.
+        {
+            let mut caches = self
+                .collection_caches
+                .write()
+                .expect("cache collections lock poisoned");
+            let mut updated = (**caches).clone();
+            updated.insert(collection_path.clone(), mem_cache);
+            *caches = Arc::new(updated);
+        }
+
+        let target_params = crate::cache::target_params_for_collection(
+            &collection_config,
+            Some(FirestoreListenerTargetResumeType::ReadTime(read_from_time)),
+        );
+
+        {
+            let mut config = self
+                .config
+                .write()
+                .expect("cache configuration lock poisoned");
+            *config = Arc::new(
+                (**config)
+                    .clone()
+                    .add_collection_config_at(db.get_documents_path(), collection_config),
+            );
+        }
+
+        Ok(target_params)
+    }
+
+    async fn remove_collection(
+        &self,
+        collection_path: &str,
+    ) -> FirestoreResult<Option<FirestoreListenerTarget>> {
+        // The configuration goes first, so reads stop using the collection immediately and any
+        // listener event arriving before the target is dropped is ignored.
+        let removed = {
+            let mut config = self
+                .config
+                .write()
+                .expect("cache configuration lock poisoned");
+            let mut updated = (**config).clone();
+            let removed = updated.collections.remove(collection_path);
+            *config = Arc::new(updated);
+            removed
+        };
+
+        let Some(removed) = removed else {
+            return Ok(None);
+        };
+
+        let mem_cache = {
+            let mut caches = self
+                .collection_caches
+                .write()
+                .expect("cache collections lock poisoned");
+            let mut updated = (**caches).clone();
+            let mem_cache = updated.remove(collection_path);
+            *caches = Arc::new(updated);
+            mem_cache
+        };
+
+        if let Some(mem_cache) = mem_cache {
+            debug!(
+                collection_path,
+                "Dropping the cache of a removed collection."
+            );
+            mem_cache.invalidate_all();
+            mem_cache.run_pending_tasks().await;
+        }
+
+        self.suspended_collections
+            .write()
+            .expect("cache suspended collections lock poisoned")
+            .remove(collection_path);
+
+        Ok(Some(removed.listener_target))
+    }
+
     async fn shutdown(&self) -> Result<(), FirestoreError> {
-        Ok(())
+        // Handles to the backend outlive the cache - `read_through_cache` clones one into every
+        // `FirestoreDb` it is attached to - so releasing the documents here rather than waiting to
+        // be dropped is what actually frees the memory.
+        debug!("Releasing the cached documents of the in-memory cache.");
+        self.invalidate_all().await
     }
 
     async fn on_listen_event(&self, event: FirestoreListenEvent) -> FirestoreResult<()> {
@@ -294,7 +509,7 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
             FirestoreListenEvent::DocumentChange(doc_change) => {
                 if let Some(doc) = doc_change.document {
                     let (collection_path, document_id) = split_document_path(&doc.name);
-                    if let Some(mem_cache) = self.collection_caches.get(collection_path) {
+                    if let Some(mem_cache) = self.collection_cache(collection_path) {
                         trace!(
                             doc_name = ?doc.name,
                             "Writing document to cache due to listener event.",
@@ -305,17 +520,47 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
                 Ok(())
             }
             FirestoreListenEvent::DocumentDelete(doc_deleted) => {
-                let (collection_path, document_id) = split_document_path(&doc_deleted.document);
-                if let Some(mem_cache) = self.collection_caches.get(collection_path) {
-                    trace!(
-                        deleted_doc = ?doc_deleted.document.as_str(),
-                        "Removing document from cache due to listener event.",
-                    );
-                    mem_cache.remove(document_id).await;
+                self.evict_doc_by_path(&doc_deleted.document).await;
+                Ok(())
+            }
+            // The document went out of view of the target. Firestore sends this instead of a
+            // delete when it cannot send the new value, so keeping the document would leave the
+            // cache serving something the caller can no longer read.
+            FirestoreListenEvent::DocumentRemove(doc_removed) => {
+                self.evict_doc_by_path(&doc_removed.document).await;
+                Ok(())
+            }
+            FirestoreListenEvent::TargetChange(ref target_change) => {
+                match crate::cache::cache_target_change_action(&self.config(), target_change) {
+                    crate::cache::FirestoreCacheTargetChangeAction::SuspendAndInvalidate(paths) => {
+                        {
+                            let mut suspended = self
+                                .suspended_collections
+                                .write()
+                                .expect("cache suspended collections lock poisoned");
+                            suspended.extend(paths.iter().cloned());
+                        }
+                        for collection_path in &paths {
+                            self.invalidate_collection(collection_path).await;
+                        }
+                    }
+                    crate::cache::FirestoreCacheTargetChangeAction::Resume(paths) => {
+                        let mut suspended = self
+                            .suspended_collections
+                            .write()
+                            .expect("cache suspended collections lock poisoned");
+                        for collection_path in &paths {
+                            suspended.remove(collection_path);
+                        }
+                    }
+                    crate::cache::FirestoreCacheTargetChangeAction::Ignore => {}
                 }
                 Ok(())
             }
-            _ => Ok(()),
+            _ => {
+                trace!(?event, "Ignoring a listen event the cache does not act on.");
+                Ok(())
+            }
         }
     }
 }
@@ -328,7 +573,7 @@ impl FirestoreCacheDocsByPathSupport for FirestoreMemoryCacheBackend {
     ) -> FirestoreResult<Option<FirestoreDocument>> {
         let (collection_path, document_id) = split_document_path(document_path);
 
-        match self.collection_caches.get(collection_path) {
+        match self.collection_cache(collection_path) {
             Some(mem_cache) => Ok(mem_cache.get(document_id).await),
             None => Ok(None),
         }
@@ -337,7 +582,7 @@ impl FirestoreCacheDocsByPathSupport for FirestoreMemoryCacheBackend {
     async fn update_doc_by_path(&self, document: &FirestoreDocument) -> FirestoreResult<()> {
         let (collection_path, document_id) = split_document_path(&document.name);
 
-        match self.collection_caches.get(collection_path) {
+        match self.collection_cache(collection_path) {
             Some(mem_cache) => {
                 mem_cache
                     .insert(document_id.to_string(), document.clone())
@@ -353,11 +598,13 @@ impl FirestoreCacheDocsByPathSupport for FirestoreMemoryCacheBackend {
         collection_path: &str,
     ) -> FirestoreResult<FirestoreCachedValue<BoxStream<'b, FirestoreResult<FirestoreDocument>>>>
     {
-        if !self.config.is_collection_listable(collection_path) {
+        if !self.config().is_collection_listable(collection_path)
+            || self.is_suspended(collection_path)
+        {
             return Ok(FirestoreCachedValue::SkipCache);
         }
 
-        match self.collection_caches.get(collection_path) {
+        match self.collection_cache(collection_path) {
             Some(mem_cache) => {
                 let all_docs: Vec<FirestoreResult<FirestoreDocument>> =
                     mem_cache.iter().map(|(_, doc)| Ok(doc)).collect();
@@ -375,7 +622,9 @@ impl FirestoreCacheDocsByPathSupport for FirestoreMemoryCacheBackend {
         query: &FirestoreQueryParams,
     ) -> FirestoreResult<FirestoreCachedValue<BoxStream<'b, FirestoreResult<FirestoreDocument>>>>
     {
-        if !self.config.is_collection_listable(collection_path) {
+        if !self.config().is_collection_listable(collection_path)
+            || self.is_suspended(collection_path)
+        {
             return Ok(FirestoreCachedValue::SkipCache);
         }
 
@@ -388,5 +637,209 @@ impl FirestoreCacheDocsByPathSupport for FirestoreMemoryCacheBackend {
         } else {
             Ok(FirestoreCachedValue::SkipCache)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gcloud_sdk::google::firestore::v1::{
+        DocumentChange, DocumentDelete, DocumentRemove, TargetChange,
+    };
+
+    const DOCS: &str = "projects/test/databases/(default)/documents";
+
+    fn backend(
+        collections: &[(&str, u32, FirestoreCacheCollectionLoadMode)],
+    ) -> FirestoreMemoryCacheBackend {
+        let config = collections.iter().fold(
+            FirestoreCacheConfiguration::new(),
+            |config, (name, target, load_mode)| {
+                config.add_collection_config_at(
+                    DOCS,
+                    FirestoreCacheCollectionConfiguration::new(
+                        name,
+                        FirestoreListenerTarget::new(*target),
+                        *load_mode,
+                    ),
+                )
+            },
+        );
+
+        FirestoreMemoryCacheBackend::new(config).expect("backend")
+    }
+
+    fn preloaded(collections: &[(&str, u32)]) -> FirestoreMemoryCacheBackend {
+        let collections: Vec<_> = collections
+            .iter()
+            .map(|(name, target)| {
+                (
+                    *name,
+                    *target,
+                    FirestoreCacheCollectionLoadMode::PreloadAllDocs,
+                )
+            })
+            .collect();
+        backend(&collections)
+    }
+
+    fn doc_path(collection: &str, id: &str) -> String {
+        format!("{DOCS}/{collection}/{id}")
+    }
+
+    async fn seed(backend: &FirestoreMemoryCacheBackend, collection: &str, id: &str) {
+        backend
+            .update_doc_by_path(&FirestoreDocument {
+                name: doc_path(collection, id),
+                ..Default::default()
+            })
+            .await
+            .expect("seeded document");
+    }
+
+    async fn cached(backend: &FirestoreMemoryCacheBackend, collection: &str, id: &str) -> bool {
+        backend
+            .get_doc_by_path(&doc_path(collection, id))
+            .await
+            .expect("cache lookup")
+            .is_some()
+    }
+
+    fn target_change(
+        change_type: FirestoreListenerTargetChangeType,
+        target_ids: Vec<i32>,
+    ) -> FirestoreListenEvent {
+        FirestoreListenEvent::TargetChange(TargetChange {
+            target_change_type: change_type as i32,
+            target_ids,
+            ..Default::default()
+        })
+    }
+
+    async fn is_listable(backend: &FirestoreMemoryCacheBackend, collection: &str) -> bool {
+        matches!(
+            backend
+                .list_all_docs(&format!("{DOCS}/{collection}"))
+                .await
+                .expect("listing"),
+            FirestoreCachedValue::UseCached(_)
+        )
+    }
+
+    #[tokio::test]
+    async fn document_remove_evicts_the_document() {
+        let backend = preloaded(&[("a", 1000)]);
+        seed(&backend, "a", "one").await;
+
+        backend
+            .on_listen_event(FirestoreListenEvent::DocumentRemove(DocumentRemove {
+                document: doc_path("a", "one"),
+                ..Default::default()
+            }))
+            .await
+            .expect("event handled");
+
+        assert!(!cached(&backend, "a", "one").await);
+    }
+
+    #[tokio::test]
+    async fn document_delete_still_evicts_the_document() {
+        let backend = preloaded(&[("a", 1000)]);
+        seed(&backend, "a", "one").await;
+
+        backend
+            .on_listen_event(FirestoreListenEvent::DocumentDelete(DocumentDelete {
+                document: doc_path("a", "one"),
+                ..Default::default()
+            }))
+            .await
+            .expect("event handled");
+
+        assert!(!cached(&backend, "a", "one").await);
+    }
+
+    #[tokio::test]
+    async fn a_reset_empties_only_the_collection_of_that_target() {
+        let backend = preloaded(&[("a", 1000), ("b", 1001)]);
+        seed(&backend, "a", "one").await;
+        seed(&backend, "b", "one").await;
+
+        backend
+            .on_listen_event(target_change(
+                FirestoreListenerTargetChangeType::Reset,
+                vec![1000],
+            ))
+            .await
+            .expect("event handled");
+
+        assert!(!cached(&backend, "a", "one").await);
+        assert!(cached(&backend, "b", "one").await);
+    }
+
+    #[tokio::test]
+    async fn a_reset_stops_the_collection_answering_listings_until_it_is_current() {
+        let backend = preloaded(&[("a", 1000), ("b", 1001)]);
+
+        assert!(is_listable(&backend, "a").await);
+
+        backend
+            .on_listen_event(target_change(
+                FirestoreListenerTargetChangeType::Reset,
+                vec![1000],
+            ))
+            .await
+            .expect("event handled");
+
+        // Serving a listing here would look complete while holding a half-replayed collection.
+        assert!(!is_listable(&backend, "a").await);
+        assert!(is_listable(&backend, "b").await);
+
+        backend
+            .on_listen_event(target_change(
+                FirestoreListenerTargetChangeType::Current,
+                vec![1000],
+            ))
+            .await
+            .expect("event handled");
+
+        assert!(is_listable(&backend, "a").await);
+    }
+
+    #[tokio::test]
+    async fn a_reset_without_target_ids_affects_every_collection() {
+        let backend = preloaded(&[("a", 1000), ("b", 1001)]);
+        seed(&backend, "a", "one").await;
+        seed(&backend, "b", "one").await;
+
+        backend
+            .on_listen_event(target_change(
+                FirestoreListenerTargetChangeType::Reset,
+                vec![],
+            ))
+            .await
+            .expect("event handled");
+
+        assert!(!cached(&backend, "a", "one").await);
+        assert!(!cached(&backend, "b", "one").await);
+        assert!(!is_listable(&backend, "a").await);
+        assert!(!is_listable(&backend, "b").await);
+    }
+
+    #[tokio::test]
+    async fn events_for_unconfigured_collections_are_ignored() {
+        let backend = preloaded(&[("a", 1000)]);
+
+        backend
+            .on_listen_event(FirestoreListenEvent::DocumentChange(DocumentChange {
+                document: Some(FirestoreDocument {
+                    name: doc_path("elsewhere", "one"),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+            .await
+            .expect("event handled");
+
+        assert!(!cached(&backend, "elsewhere", "one").await);
     }
 }

--- a/src/cache/backends/memory_backend.rs
+++ b/src/cache/backends/memory_backend.rs
@@ -381,7 +381,7 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
         _options: &FirestoreCacheOptions,
         db: &FirestoreDb,
     ) -> Result<Vec<FirestoreListenerTargetParams>, FirestoreError> {
-        let read_from_time = crate::cache::cache_target_read_time();
+        let read_from_time = FirestoreCacheCollectionConfiguration::listener_read_time();
 
         self.preload_collections(db).await?;
 
@@ -390,10 +390,9 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
             .collections
             .values()
             .map(|collection_config| {
-                crate::cache::target_params_for_collection(
-                    collection_config,
-                    Some(FirestoreListenerTargetResumeType::ReadTime(read_from_time)),
-                )
+                collection_config.listener_target_params(Some(
+                    FirestoreListenerTargetResumeType::ReadTime(read_from_time),
+                ))
             })
             .collect())
     }
@@ -419,7 +418,7 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
     ) -> FirestoreResult<FirestoreListenerTargetParams> {
         // Captured before reading anything, so that writes landing during the preload are still
         // delivered once the listener target attaches from this point in time.
-        let read_from_time = crate::cache::cache_target_read_time();
+        let read_from_time = FirestoreCacheCollectionConfiguration::listener_read_time();
         let collection_path = collection_config.resolve_collection_path(db.get_documents_path());
 
         let mem_cache = (self.collection_mem_options)(collection_path.as_str()).build();
@@ -441,10 +440,9 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
             *caches = Arc::new(updated);
         }
 
-        let target_params = crate::cache::target_params_for_collection(
-            &collection_config,
-            Some(FirestoreListenerTargetResumeType::ReadTime(read_from_time)),
-        );
+        let target_params = collection_config.listener_target_params(Some(
+            FirestoreListenerTargetResumeType::ReadTime(read_from_time),
+        ));
 
         {
             let mut config = self
@@ -581,7 +579,7 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
                 Ok(())
             }
             FirestoreListenEvent::TargetChange(ref target_change) => {
-                match crate::cache::cache_target_change_action(&self.config(), target_change) {
+                match self.config().target_change_action(target_change) {
                     crate::cache::FirestoreCacheTargetChangeAction::SuspendAndInvalidate(
                         invalidations,
                     ) => {

--- a/src/cache/backends/memory_backend.rs
+++ b/src/cache/backends/memory_backend.rs
@@ -41,6 +41,13 @@ pub type FirestoreMemCacheOptions = CacheBuilder<String, FirestoreDocument, Fire
 /// # }
 /// ```
 pub struct FirestoreMemoryCacheBackend {
+    /// Whether an entry count can be compared against Firestore's.
+    ///
+    /// False when the cache expires entries on its own, because then a shortfall is this cache
+    /// doing its job rather than a divergence from the server.
+    count_authoritative: bool,
+    /// The per-collection capacity, above which eviction makes the count meaningless.
+    max_capacity: u64,
     /// Behind a lock so that collections can be added and removed while the cache runs. Readers
     /// clone the `Arc` out and drop the guard, so no guard is ever held across an await.
     config: std::sync::RwLock<Arc<FirestoreCacheConfiguration>>,
@@ -139,7 +146,10 @@ impl FirestoreMemoryCacheBackend {
         config: FirestoreCacheConfiguration,
         options: FirestoreMemoryCacheOptions,
     ) -> FirestoreResult<Self> {
-        Self::with_collection_options(config, move |_| {
+        let count_authoritative = options.time_to_live.is_none() && options.time_to_idle.is_none();
+        let max_capacity = options.max_capacity;
+
+        let backend = Self::with_collection_options(config, move |_| {
             let mut builder = FirestoreMemCache::builder().max_capacity(options.max_capacity);
             if let Some(time_to_live) = options.time_to_live {
                 builder = builder.time_to_live(time_to_live);
@@ -148,6 +158,12 @@ impl FirestoreMemoryCacheBackend {
                 builder = builder.time_to_idle(time_to_idle);
             }
             builder
+        })?;
+
+        Ok(Self {
+            count_authoritative,
+            max_capacity,
+            ..backend
         })
     }
 
@@ -173,6 +189,10 @@ impl FirestoreMemoryCacheBackend {
             .collect();
 
         Ok(Self {
+            // An arbitrary moka builder can expire entries however it likes, so counts from a
+            // backend built this way are never comparable with Firestore's.
+            count_authoritative: false,
+            max_capacity: u64::MAX,
             config: std::sync::RwLock::new(Arc::new(config)),
             collection_caches: std::sync::RwLock::new(Arc::new(collection_caches)),
             collection_mem_options: Box::new(collection_mem_options),
@@ -203,6 +223,14 @@ impl FirestoreMemoryCacheBackend {
             .read()
             .expect("cache collections lock poisoned")
             .clone()
+    }
+
+    /// Stops a collection answering `list`/`query` until Firestore reports it consistent again.
+    fn suspend_collection(&self, collection_path: &str) {
+        self.suspended_collections
+            .write()
+            .expect("cache suspended collections lock poisoned")
+            .insert(collection_path.to_string());
     }
 
     /// Whether a collection is mid-replay after Firestore reset or removed its listener target.
@@ -483,6 +511,36 @@ impl FirestoreCacheBackend for FirestoreMemoryCacheBackend {
         Ok(Some(removed.listener_target))
     }
 
+    async fn begin_collection_resync(&self, collection_path: &str) -> FirestoreResult<()> {
+        if !self.config().collections.contains_key(collection_path) {
+            return Ok(());
+        }
+        self.suspend_collection(collection_path);
+        self.invalidate_collection(collection_path).await;
+        Ok(())
+    }
+
+    async fn authoritative_doc_count(&self, collection_path: &str) -> FirestoreResult<Option<u64>> {
+        let config = self.config();
+        let Some(collection_config) = config.collections.get(collection_path) else {
+            return Ok(None);
+        };
+        if !self.count_authoritative || !collection_config.collection_load_mode.is_preloading() {
+            return Ok(None);
+        }
+
+        let Some(mem_cache) = self.collection_cache(collection_path) else {
+            return Ok(None);
+        };
+
+        // `entry_count` is otherwise an estimate.
+        mem_cache.run_pending_tasks().await;
+        let count = mem_cache.entry_count();
+
+        // At capacity a shortfall is eviction, not divergence.
+        Ok((count < self.max_capacity).then_some(count))
+    }
+
     async fn shutdown(&self) -> Result<(), FirestoreError> {
         // Handles to the backend outlive the cache - `read_through_cache` clones one into every
         // `FirestoreDb` it is attached to - so releasing the documents here rather than waiting to
@@ -667,6 +725,7 @@ mod tests {
     use gcloud_sdk::google::firestore::v1::{
         DocumentChange, DocumentDelete, DocumentRemove, TargetChange,
     };
+    use std::time::Duration;
 
     const DOCS: &str = "projects/test/databases/(default)/documents";
 
@@ -920,6 +979,62 @@ mod tests {
 
         assert!(!cached(&backend, "a", "one").await);
         assert!(cached(&backend, "a", "other").await);
+    }
+
+    #[tokio::test]
+    async fn a_preloaded_collection_reports_a_comparable_document_count() {
+        let backend = preloaded(&[("a", 1000)]);
+        seed(&backend, "a", "one").await;
+        seed(&backend, "a", "two").await;
+
+        assert_eq!(
+            backend
+                .authoritative_doc_count(&format!("{DOCS}/a"))
+                .await
+                .unwrap(),
+            Some(2)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_lazily_filled_collection_reports_no_comparable_count() {
+        let backend = backend(&[("a", 1000, FirestoreCacheCollectionLoadMode::PreloadNone)]);
+        seed(&backend, "a", "one").await;
+
+        // It holds whatever happened to be read, so its count says nothing about Firestore's.
+        assert_eq!(
+            backend
+                .authoritative_doc_count(&format!("{DOCS}/a"))
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cache_that_expires_entries_reports_no_comparable_count() {
+        let config = FirestoreCacheConfiguration::new().add_collection_config_at(
+            DOCS,
+            FirestoreCacheCollectionConfiguration::new(
+                "a",
+                FirestoreListenerTarget::new(1000),
+                FirestoreCacheCollectionLoadMode::PreloadAllDocs,
+            ),
+        );
+        let backend = FirestoreMemoryCacheBackend::with_options(
+            config,
+            FirestoreMemoryCacheOptions::new().with_time_to_live(Duration::from_secs(60)),
+        )
+        .expect("backend");
+
+        // A shortfall here is this cache expiring entries, not Firestore having fewer documents.
+        assert_eq!(
+            backend
+                .authoritative_doc_count(&format!("{DOCS}/a"))
+                .await
+                .unwrap(),
+            None
+        );
     }
 
     #[tokio::test]

--- a/src/cache/backends/persistent_backend.rs
+++ b/src/cache/backends/persistent_backend.rs
@@ -9,8 +9,9 @@ use futures::StreamExt;
 use gcloud_sdk::google::firestore::v1::Document;
 use gcloud_sdk::prost::Message;
 use redb::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::*;
 
 /// A disk-backed cache, storing documents as protobuf in a
@@ -34,8 +35,19 @@ use tracing::*;
 /// # }
 /// ```
 pub struct FirestorePersistentCacheBackend {
-    pub config: FirestoreCacheConfiguration,
-    redb: Database,
+    /// Behind a lock so that collections can be added and removed while the cache runs. Readers
+    /// clone the `Arc` out and drop the guard, so no guard is ever held across an await.
+    config: std::sync::RwLock<Arc<FirestoreCacheConfiguration>>,
+    /// `None` once the cache has been shut down.
+    ///
+    /// The database holds an exclusive lock on its file, so closing it is the only way to release
+    /// that lock without dropping every handle to the backend - and handles outlive the cache,
+    /// because `read_through_cache` clones one into each `FirestoreDb` it is attached to.
+    redb: std::sync::RwLock<Option<Database>>,
+    /// Collections whose listener target Firestore has reset or removed, and which are therefore
+    /// mid-replay. They must not answer `list`/`query` until the replay completes, because what
+    /// they hold in the meantime is a partial view that would look like a complete one.
+    suspended_collections: std::sync::RwLock<HashSet<String>>,
 }
 
 /// Tuning options for [`FirestorePersistentCacheBackend`].
@@ -111,18 +123,117 @@ impl FirestorePersistentCacheBackend {
         db.compact()?;
         info!("Successfully opened database for persistent cache.");
 
-        Ok(Self { config, redb: db })
+        Ok(Self {
+            config: std::sync::RwLock::new(Arc::new(config)),
+            redb: std::sync::RwLock::new(Some(db)),
+            suspended_collections: std::sync::RwLock::new(HashSet::new()),
+        })
+    }
+
+    /// A snapshot of the collections this backend currently caches.
+    pub fn config(&self) -> Arc<FirestoreCacheConfiguration> {
+        self.config
+            .read()
+            .expect("cache configuration lock poisoned")
+            .clone()
+    }
+
+    /// Borrows the open database, or reports that the cache has been shut down.
+    ///
+    /// The guard must not be held across an await - every caller uses it inside a synchronous
+    /// block, which is what keeps `shutdown` able to take the database away promptly.
+    fn open_db(&self) -> FirestoreResult<std::sync::RwLockReadGuard<'_, Option<Database>>> {
+        let guard = self.redb.read().expect("cache database lock poisoned");
+        if guard.is_none() {
+            return Err(FirestoreError::CacheError(FirestoreCacheError::new(
+                FirestoreErrorPublicGenericDetails::new("CacheShutdown".into()),
+                "This persistent cache has been shut down and no longer holds its database."
+                    .to_string(),
+            )));
+        }
+        Ok(guard)
+    }
+
+    /// Whether the cache is still usable. Reads fall back to Firestore once it is not.
+    fn is_open(&self) -> bool {
+        self.redb
+            .read()
+            .expect("cache database lock poisoned")
+            .is_some()
+    }
+
+    /// Whether a collection is mid-replay after Firestore reset or removed its listener target.
+    fn is_suspended(&self, collection_path: &str) -> bool {
+        self.suspended_collections
+            .read()
+            .expect("cache suspended collections lock poisoned")
+            .contains(collection_path)
+    }
+
+    /// Drops everything cached for one collection, leaving its table in place.
+    fn invalidate_collection(&self, collection_path: &str) -> FirestoreResult<()> {
+        if !self.config().collections.contains_key(collection_path) {
+            return Ok(());
+        }
+
+        let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
+        let write_txn = self
+            .open_db()?
+            .as_ref()
+            .expect("database checked open")
+            .begin_write()?;
+        {
+            debug!(
+                collection_path,
+                "Invalidating collection and draining the corresponding table.",
+            );
+            let mut table = write_txn.open_table(td)?;
+            table.retain(|_, _| false)?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    /// Removes a document from the cache, wherever the listener said it went.
+    fn evict_doc_by_path(&self, document_path: &str) -> FirestoreResult<()> {
+        let (collection_path, document_id) = split_document_path(document_path);
+
+        if !self.config().collections.contains_key(collection_path) {
+            return Ok(());
+        }
+
+        trace!(
+            document_path,
+            "Removing document from cache due to listener event.",
+        );
+
+        let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
+        let write_txn = self
+            .open_db()?
+            .as_ref()
+            .expect("database checked open")
+            .begin_write()?;
+        {
+            let mut table = write_txn.open_table(td)?;
+            table.remove(document_id)?;
+        }
+        write_txn.commit()?;
+        Ok(())
     }
 
     async fn preload_collections(&self, db: &FirestoreDb) -> Result<(), FirestoreError> {
-        for (collection_path, config) in &self.config.collections {
+        for (collection_path, config) in &self.config().collections {
             let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path.as_str());
 
             match config.collection_load_mode {
                 FirestoreCacheCollectionLoadMode::PreloadAllDocs
                 | FirestoreCacheCollectionLoadMode::PreloadAllIfEmpty => {
                     let existing_records = {
-                        let read_tx = self.redb.begin_read()?;
+                        let read_tx = self
+                            .open_db()?
+                            .as_ref()
+                            .expect("database checked open")
+                            .begin_read()?;
                         if read_tx
                             .list_tables()?
                             .any(|t| t.name() == collection_path.as_str())
@@ -187,7 +298,11 @@ impl FirestorePersistentCacheBackend {
                         FirestoreCacheCollectionLoadMode::PreloadAllDocs
                     ) || existing_records == 0
                     {
-                        let read_tx = self.redb.begin_read()?;
+                        let read_tx = self
+                            .open_db()?
+                            .as_ref()
+                            .expect("database checked open")
+                            .begin_read()?;
                         let table = read_tx.open_table(td)?;
                         table.len()?
                     } else {
@@ -200,7 +315,11 @@ impl FirestorePersistentCacheBackend {
                     );
                 }
                 FirestoreCacheCollectionLoadMode::PreloadNone => {
-                    let tx = self.redb.begin_write()?;
+                    let tx = self
+                        .open_db()?
+                        .as_ref()
+                        .expect("database checked open")
+                        .begin_write()?;
                     debug!(collection_path, "Creating corresponding collection table.",);
                     tx.open_table(td)?;
                     tx.commit()?;
@@ -213,7 +332,11 @@ impl FirestorePersistentCacheBackend {
     fn write_batch_docs(&self, collection_path: &str, docs: Vec<Document>) -> FirestoreResult<()> {
         let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
 
-        let write_txn = self.redb.begin_write()?;
+        let write_txn = self
+            .open_db()?
+            .as_ref()
+            .expect("database checked open")
+            .begin_write()?;
         {
             let mut table = write_txn.open_table(td)?;
 
@@ -245,10 +368,14 @@ impl FirestorePersistentCacheBackend {
     fn write_document(&self, doc: &Document) -> FirestoreResult<()> {
         let (collection_path, document_id) = split_document_path(&doc.name);
 
-        if self.config.collections.contains_key(collection_path) {
+        if self.config().collections.contains_key(collection_path) {
             let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
 
-            let write_txn = self.redb.begin_write()?;
+            let write_txn = self
+                .open_db()?
+                .as_ref()
+                .expect("database checked open")
+                .begin_write()?;
             {
                 let mut table = write_txn.open_table(td)?;
                 let doc_bytes = Self::document_to_buf(doc)?;
@@ -261,9 +388,39 @@ impl FirestorePersistentCacheBackend {
         }
     }
 
+    /// Creates a collection's table if it does not exist yet.
+    fn create_collection_table(&self, collection_path: &str) -> FirestoreResult<()> {
+        let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
+        let tx = self
+            .open_db()?
+            .as_ref()
+            .expect("database checked open")
+            .begin_write()?;
+        tx.open_table(td)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Deletes a collection's table entirely. Returns whether there was one.
+    fn drop_collection_table(&self, collection_path: &str) -> FirestoreResult<bool> {
+        let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
+        let tx = self
+            .open_db()?
+            .as_ref()
+            .expect("database checked open")
+            .begin_write()?;
+        let existed = tx.delete_table(td)?;
+        tx.commit()?;
+        Ok(existed)
+    }
+
     fn table_len(&self, collection_id: &str) -> FirestoreResult<u64> {
         let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_id);
-        let read_tx = self.redb.begin_read()?;
+        let read_tx = self
+            .open_db()?
+            .as_ref()
+            .expect("database checked open")
+            .begin_read()?;
         let len = read_tx.open_table(td)?.len()?;
         Ok(len)
     }
@@ -275,7 +432,11 @@ impl FirestorePersistentCacheBackend {
     ) -> FirestoreResult<BoxStream<'b, FirestoreResult<FirestoreDocument>>> {
         let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
 
-        let read_tx = self.redb.begin_read()?;
+        let read_tx = self
+            .open_db()?
+            .as_ref()
+            .expect("database checked open")
+            .begin_read()?;
         let table = read_tx.open_table(td)?;
         let iter = table.iter()?;
 
@@ -308,7 +469,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
         self.preload_collections(db).await?;
 
         Ok(self
-            .config
+            .config()
             .collections
             .iter()
             .map(|(collection_path, collection_config)| {
@@ -334,10 +495,14 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
     }
 
     async fn invalidate_all(&self) -> FirestoreResult<()> {
-        for collection_path in self.config.collections.keys() {
+        for collection_path in self.config().collections.keys() {
             let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path.as_str());
 
-            let write_txn = self.redb.begin_write()?;
+            let write_txn = self
+                .open_db()?
+                .as_ref()
+                .expect("database checked open")
+                .begin_write()?;
             {
                 debug!(
                     collection_path,
@@ -352,11 +517,140 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
         Ok(())
     }
 
+    fn cache_configuration(&self) -> Arc<FirestoreCacheConfiguration> {
+        self.config()
+    }
+
+    async fn add_collection(
+        &self,
+        _options: &FirestoreCacheOptions,
+        db: &FirestoreDb,
+        collection_config: FirestoreCacheCollectionConfiguration,
+    ) -> FirestoreResult<FirestoreListenerTargetParams> {
+        // Captured before reading anything, so that writes landing during the preload are still
+        // delivered once the listener target attaches from this point in time.
+        let read_from_time = FirestoreInstant::now();
+        let collection_path = collection_config.resolve_collection_path(db.get_documents_path());
+
+        // A collection added at runtime starts from nothing - `remove_collection` deletes the
+        // table - so both preloading modes mean the same thing here.
+        self.create_collection_table(&collection_path)?;
+
+        if collection_config.collection_load_mode.is_preloading() {
+            debug!(
+                collection_path = collection_path.as_str(),
+                "Preloading collection."
+            );
+
+            let params = if let Some(parent) = &collection_config.parent {
+                db.fluent()
+                    .select()
+                    .from(collection_config.collection_name.as_str())
+                    .parent(parent)
+            } else {
+                db.fluent()
+                    .select()
+                    .from(collection_config.collection_name.as_str())
+            };
+
+            params
+                .stream_query()
+                .await?
+                .ready_chunks(100)
+                .for_each(|docs| async {
+                    if let Err(err) = self.write_batch_docs(&collection_path, docs) {
+                        error!(?err, "Error while preloading collection.");
+                    }
+                })
+                .await;
+
+            info!(
+                collection_path = collection_path.as_str(),
+                updated_records = self.table_len(&collection_path).unwrap_or(0),
+                "Preloading collection has been finished.",
+            );
+        }
+
+        let target_params = crate::cache::target_params_for_collection(
+            &collection_config,
+            Some(FirestoreListenerTargetResumeType::ReadTime(read_from_time)),
+        );
+
+        // Published only now: until this point the collection does not exist as far as reads are
+        // concerned, so no listing can see it half filled.
+        {
+            let mut config = self
+                .config
+                .write()
+                .expect("cache configuration lock poisoned");
+            *config = Arc::new(
+                (**config)
+                    .clone()
+                    .add_collection_config_at(db.get_documents_path(), collection_config),
+            );
+        }
+
+        Ok(target_params)
+    }
+
+    async fn remove_collection(
+        &self,
+        collection_path: &str,
+    ) -> FirestoreResult<Option<FirestoreListenerTarget>> {
+        // The configuration goes first, so reads stop using the collection immediately and any
+        // listener event arriving before the target is dropped is ignored.
+        let removed = {
+            let mut config = self
+                .config
+                .write()
+                .expect("cache configuration lock poisoned");
+            let mut updated = (**config).clone();
+            let removed = updated.collections.remove(collection_path);
+            *config = Arc::new(updated);
+            removed
+        };
+
+        let Some(removed) = removed else {
+            return Ok(None);
+        };
+
+        debug!(
+            collection_path,
+            "Dropping the table of a removed collection."
+        );
+        self.drop_collection_table(collection_path)?;
+
+        self.suspended_collections
+            .write()
+            .expect("cache suspended collections lock poisoned")
+            .remove(collection_path);
+
+        Ok(Some(removed.listener_target))
+    }
+
     async fn shutdown(&self) -> Result<(), FirestoreError> {
+        // Closing the database is what releases its exclusive file lock, so that another cache can
+        // be opened over the same directory in this process. Dropping it here rather than with the
+        // backend matters because handles to the backend outlive the cache: `read_through_cache`
+        // clones one into every `FirestoreDb` it is attached to.
+        let closed = self
+            .redb
+            .write()
+            .expect("cache database lock poisoned")
+            .take();
+
+        if closed.is_some() {
+            debug!("Closing the database of the persistent cache.");
+        }
+        drop(closed);
         Ok(())
     }
 
     async fn on_listen_event(&self, event: FirestoreListenEvent) -> FirestoreResult<()> {
+        if !self.is_open() {
+            return Ok(());
+        }
+
         match event {
             FirestoreListenEvent::DocumentChange(doc_change) => {
                 if let Some(doc) = doc_change.document {
@@ -370,26 +664,47 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
                 Ok(())
             }
             FirestoreListenEvent::DocumentDelete(doc_deleted) => {
-                let (collection_path, document_id) = split_document_path(&doc_deleted.document);
-
-                if self.config.collections.contains_key(collection_path) {
-                    trace!(
-                        deleted_doc = ?doc_deleted.document.as_str(),
-                        "Removing document from cache due to listener event.",
-                    );
-
-                    let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
-
-                    let write_txn = self.redb.begin_write()?;
-                    {
-                        let mut table = write_txn.open_table(td)?;
-                        table.remove(document_id)?;
+                self.evict_doc_by_path(&doc_deleted.document)?;
+                Ok(())
+            }
+            // The document went out of view of the target. Firestore sends this instead of a
+            // delete when it cannot send the new value, so keeping the document would leave the
+            // cache serving something the caller can no longer read.
+            FirestoreListenEvent::DocumentRemove(doc_removed) => {
+                self.evict_doc_by_path(&doc_removed.document)?;
+                Ok(())
+            }
+            FirestoreListenEvent::TargetChange(ref target_change) => {
+                match crate::cache::cache_target_change_action(&self.config(), target_change) {
+                    crate::cache::FirestoreCacheTargetChangeAction::SuspendAndInvalidate(paths) => {
+                        {
+                            let mut suspended = self
+                                .suspended_collections
+                                .write()
+                                .expect("cache suspended collections lock poisoned");
+                            suspended.extend(paths.iter().cloned());
+                        }
+                        for collection_path in &paths {
+                            self.invalidate_collection(collection_path)?;
+                        }
                     }
-                    write_txn.commit()?;
+                    crate::cache::FirestoreCacheTargetChangeAction::Resume(paths) => {
+                        let mut suspended = self
+                            .suspended_collections
+                            .write()
+                            .expect("cache suspended collections lock poisoned");
+                        for collection_path in &paths {
+                            suspended.remove(collection_path);
+                        }
+                    }
+                    crate::cache::FirestoreCacheTargetChangeAction::Ignore => {}
                 }
                 Ok(())
             }
-            _ => Ok(()),
+            _ => {
+                trace!(?event, "Ignoring a listen event the cache does not act on.");
+                Ok(())
+            }
         }
     }
 }
@@ -401,9 +716,13 @@ impl FirestoreCacheDocsByPathSupport for FirestorePersistentCacheBackend {
         document_path: &str,
     ) -> FirestoreResult<Option<FirestoreDocument>> {
         let (collection_path, document_id) = split_document_path(document_path);
-        if self.config.collections.contains_key(collection_path) {
+        if self.is_open() && self.config().collections.contains_key(collection_path) {
             let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
-            let read_tx = self.redb.begin_read()?;
+            let read_tx = self
+                .open_db()?
+                .as_ref()
+                .expect("database checked open")
+                .begin_read()?;
             let table = read_tx.open_table(td)?;
             let value = table.get(document_id)?;
             value.map(|v| Self::buf_to_document(v.value())).transpose()
@@ -413,6 +732,10 @@ impl FirestoreCacheDocsByPathSupport for FirestorePersistentCacheBackend {
     }
 
     async fn update_doc_by_path(&self, document: &FirestoreDocument) -> FirestoreResult<()> {
+        // A shut down cache stops accepting writes rather than failing the caller's read.
+        if !self.is_open() {
+            return Ok(());
+        }
         self.write_document(document)?;
         Ok(())
     }
@@ -422,10 +745,17 @@ impl FirestoreCacheDocsByPathSupport for FirestorePersistentCacheBackend {
         collection_path: &str,
     ) -> FirestoreResult<FirestoreCachedValue<BoxStream<'b, FirestoreResult<FirestoreDocument>>>>
     {
-        if self.config.is_collection_listable(collection_path) {
+        if self.is_open()
+            && self.config().is_collection_listable(collection_path)
+            && !self.is_suspended(collection_path)
+        {
             let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
 
-            let read_tx = self.redb.begin_read()?;
+            let read_tx = self
+                .open_db()?
+                .as_ref()
+                .expect("database checked open")
+                .begin_read()?;
             let table = read_tx.open_table(td)?;
             let iter = table.iter()?;
 
@@ -451,7 +781,10 @@ impl FirestoreCacheDocsByPathSupport for FirestorePersistentCacheBackend {
         query: &FirestoreQueryParams,
     ) -> FirestoreResult<FirestoreCachedValue<BoxStream<'b, FirestoreResult<FirestoreDocument>>>>
     {
-        if self.config.is_collection_listable(collection_path) {
+        if self.is_open()
+            && self.config().is_collection_listable(collection_path)
+            && !self.is_suspended(collection_path)
+        {
             // For now only basic/simple query all supported
             let simple_query_engine = FirestoreCacheQueryEngine::new(query);
             if simple_query_engine.params_supported() {
@@ -528,5 +861,172 @@ impl From<redb::CompactionError> for FirestoreError {
             FirestoreErrorPublicGenericDetails::new("RedbCompactionError".into()),
             format!("Cache error: {db_err}"),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gcloud_sdk::google::firestore::v1::{DocumentDelete, DocumentRemove, TargetChange};
+
+    const DOCS: &str = "projects/test/databases/(default)/documents";
+
+    struct TestBackend {
+        backend: FirestorePersistentCacheBackend,
+        // Kept alive so the database file outlives the test.
+        _dir: tempfile::TempDir,
+    }
+
+    impl std::ops::Deref for TestBackend {
+        type Target = FirestorePersistentCacheBackend;
+        fn deref(&self) -> &Self::Target {
+            &self.backend
+        }
+    }
+
+    fn preloaded(collections: &[(&str, u32)]) -> TestBackend {
+        let config = collections.iter().fold(
+            FirestoreCacheConfiguration::new(),
+            |config, (name, target)| {
+                config.add_collection_config_at(
+                    DOCS,
+                    FirestoreCacheCollectionConfiguration::new(
+                        name,
+                        FirestoreListenerTarget::new(*target),
+                        FirestoreCacheCollectionLoadMode::PreloadAllDocs,
+                    ),
+                )
+            },
+        );
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let backend =
+            FirestorePersistentCacheBackend::with_options(config, dir.path().join("redb"))
+                .expect("backend");
+
+        TestBackend { backend, _dir: dir }
+    }
+
+    fn doc_path(collection: &str, id: &str) -> String {
+        format!("{DOCS}/{collection}/{id}")
+    }
+
+    async fn seed(backend: &FirestorePersistentCacheBackend, collection: &str, id: &str) {
+        backend
+            .update_doc_by_path(&FirestoreDocument {
+                name: doc_path(collection, id),
+                ..Default::default()
+            })
+            .await
+            .expect("seeded document");
+    }
+
+    async fn cached(backend: &FirestorePersistentCacheBackend, collection: &str, id: &str) -> bool {
+        backend
+            .get_doc_by_path(&doc_path(collection, id))
+            .await
+            .expect("cache lookup")
+            .is_some()
+    }
+
+    fn target_change(
+        change_type: FirestoreListenerTargetChangeType,
+        target_ids: Vec<i32>,
+    ) -> FirestoreListenEvent {
+        FirestoreListenEvent::TargetChange(TargetChange {
+            target_change_type: change_type as i32,
+            target_ids,
+            ..Default::default()
+        })
+    }
+
+    async fn is_listable(backend: &FirestorePersistentCacheBackend, collection: &str) -> bool {
+        matches!(
+            backend
+                .list_all_docs(&format!("{DOCS}/{collection}"))
+                .await
+                .expect("listing"),
+            FirestoreCachedValue::UseCached(_)
+        )
+    }
+
+    #[tokio::test]
+    async fn document_remove_evicts_the_document() {
+        let backend = preloaded(&[("a", 1000)]);
+        seed(&backend, "a", "one").await;
+
+        backend
+            .on_listen_event(FirestoreListenEvent::DocumentRemove(DocumentRemove {
+                document: doc_path("a", "one"),
+                ..Default::default()
+            }))
+            .await
+            .expect("event handled");
+
+        assert!(!cached(&backend, "a", "one").await);
+    }
+
+    #[tokio::test]
+    async fn document_delete_still_evicts_the_document() {
+        let backend = preloaded(&[("a", 1000)]);
+        seed(&backend, "a", "one").await;
+
+        backend
+            .on_listen_event(FirestoreListenEvent::DocumentDelete(DocumentDelete {
+                document: doc_path("a", "one"),
+                ..Default::default()
+            }))
+            .await
+            .expect("event handled");
+
+        assert!(!cached(&backend, "a", "one").await);
+    }
+
+    #[tokio::test]
+    async fn a_reset_empties_only_the_collection_of_that_target() {
+        let backend = preloaded(&[("a", 1000), ("b", 1001)]);
+        seed(&backend, "a", "one").await;
+        seed(&backend, "b", "one").await;
+
+        backend
+            .on_listen_event(target_change(
+                FirestoreListenerTargetChangeType::Reset,
+                vec![1000],
+            ))
+            .await
+            .expect("event handled");
+
+        assert!(!cached(&backend, "a", "one").await);
+        assert!(cached(&backend, "b", "one").await);
+    }
+
+    #[tokio::test]
+    async fn a_reset_stops_the_collection_answering_listings_until_it_is_current() {
+        let backend = preloaded(&[("a", 1000), ("b", 1001)]);
+        seed(&backend, "a", "one").await;
+        seed(&backend, "b", "one").await;
+
+        assert!(is_listable(&backend, "a").await);
+
+        backend
+            .on_listen_event(target_change(
+                FirestoreListenerTargetChangeType::Reset,
+                vec![1000],
+            ))
+            .await
+            .expect("event handled");
+
+        assert!(!is_listable(&backend, "a").await);
+        assert!(is_listable(&backend, "b").await);
+
+        backend
+            .on_listen_event(target_change(
+                FirestoreListenerTargetChangeType::Current,
+                vec![1000],
+            ))
+            .await
+            .expect("event handled");
+
+        assert!(is_listable(&backend, "a").await);
     }
 }

--- a/src/cache/backends/persistent_backend.rs
+++ b/src/cache/backends/persistent_backend.rs
@@ -194,6 +194,67 @@ impl FirestorePersistentCacheBackend {
         Ok(())
     }
 
+    /// Reads exactly the documents a collection is limited to, rather than downloading the whole
+    /// collection and throwing most of it away.
+    async fn preload_watched_documents(
+        &self,
+        db: &FirestoreDb,
+        collection_path: &str,
+        config: &FirestoreCacheCollectionConfiguration,
+    ) -> FirestoreResult<()> {
+        let Some(document_ids) = config.watched_document_ids() else {
+            return Ok(());
+        };
+
+        let selector = db
+            .fluent()
+            .select()
+            .by_id_in(config.collection_name.as_str());
+        let selector = match &config.parent {
+            Some(parent) => selector.parent(parent),
+            None => selector,
+        };
+
+        let mut stream = selector.batch(document_ids.to_vec()).await?;
+        let mut found: Vec<Document> = Vec::new();
+        while let Some((_, doc)) = stream.next().await {
+            if let Some(doc) = doc {
+                found.push(doc);
+            }
+        }
+
+        if !found.is_empty() {
+            self.write_batch_docs(collection_path, found)?;
+        }
+        Ok(())
+    }
+
+    /// Removes several documents of one collection in a single transaction.
+    fn evict_documents(
+        &self,
+        collection_path: &str,
+        document_ids: &[String],
+    ) -> FirestoreResult<()> {
+        if !self.config().collections.contains_key(collection_path) {
+            return Ok(());
+        }
+
+        let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
+        let write_txn = self
+            .open_db()?
+            .as_ref()
+            .expect("database checked open")
+            .begin_write()?;
+        {
+            let mut table = write_txn.open_table(td)?;
+            for document_id in document_ids {
+                table.remove(document_id.as_str())?;
+            }
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
     /// Removes a document from the cache, wherever the listener said it went.
     fn evict_doc_by_path(&self, document_path: &str) -> FirestoreResult<()> {
         let (collection_path, document_id) = split_document_path(document_path);
@@ -261,6 +322,16 @@ impl FirestorePersistentCacheBackend {
                         collection_path = collection_path.as_str(),
                         "Preloading collection."
                     );
+
+                    if config.watched_document_ids().is_some() {
+                        self.preload_watched_documents(db, collection_path, config)
+                            .await?;
+                        info!(
+                            collection_path = collection_path.as_str(),
+                            "Preloading watched documents has been finished.",
+                        );
+                        continue;
+                    }
 
                     let params = if let Some(parent) = &config.parent {
                         db.fluent()
@@ -368,7 +439,10 @@ impl FirestorePersistentCacheBackend {
     fn write_document(&self, doc: &Document) -> FirestoreResult<()> {
         let (collection_path, document_id) = split_document_path(&doc.name);
 
-        if self.config().collections.contains_key(collection_path) {
+        if self
+            .config()
+            .is_document_cached(collection_path, document_id)
+        {
             let td: TableDefinition<&str, &[u8]> = TableDefinition::new(collection_path);
 
             let write_txn = self
@@ -542,6 +616,31 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
                 "Preloading collection."
             );
 
+            if let Some(document_ids) = collection_config.watched_document_ids() {
+                self.preload_watched_documents(db, &collection_path, &collection_config)
+                    .await?;
+                info!(
+                    collection_path = collection_path.as_str(),
+                    watched_documents = document_ids.len(),
+                    "Preloading watched documents has been finished.",
+                );
+
+                let target_params = crate::cache::target_params_for_collection(
+                    &collection_config,
+                    Some(FirestoreListenerTargetResumeType::ReadTime(read_from_time)),
+                );
+                let mut config = self
+                    .config
+                    .write()
+                    .expect("cache configuration lock poisoned");
+                *config = Arc::new(
+                    (**config)
+                        .clone()
+                        .add_collection_config_at(db.get_documents_path(), collection_config),
+                );
+                return Ok(target_params);
+            }
+
             let params = if let Some(parent) = &collection_config.parent {
                 db.fluent()
                     .select()
@@ -676,16 +775,30 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
             }
             FirestoreListenEvent::TargetChange(ref target_change) => {
                 match crate::cache::cache_target_change_action(&self.config(), target_change) {
-                    crate::cache::FirestoreCacheTargetChangeAction::SuspendAndInvalidate(paths) => {
+                    crate::cache::FirestoreCacheTargetChangeAction::SuspendAndInvalidate(
+                        invalidations,
+                    ) => {
                         {
                             let mut suspended = self
                                 .suspended_collections
                                 .write()
                                 .expect("cache suspended collections lock poisoned");
-                            suspended.extend(paths.iter().cloned());
+                            suspended.extend(
+                                invalidations
+                                    .iter()
+                                    .map(|invalidation| invalidation.collection_path().to_string()),
+                            );
                         }
-                        for collection_path in &paths {
-                            self.invalidate_collection(collection_path)?;
+                        for invalidation in &invalidations {
+                            match invalidation {
+                                crate::cache::FirestoreCacheInvalidation::Collection(
+                                    collection_path,
+                                ) => self.invalidate_collection(collection_path)?,
+                                crate::cache::FirestoreCacheInvalidation::Documents {
+                                    collection_path,
+                                    document_ids,
+                                } => self.evict_documents(collection_path, document_ids)?,
+                            }
                         }
                     }
                     crate::cache::FirestoreCacheTargetChangeAction::Resume(paths) => {

--- a/src/cache/backends/persistent_backend.rs
+++ b/src/cache/backends/persistent_backend.rs
@@ -545,7 +545,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
         _options: &FirestoreCacheOptions,
         db: &FirestoreDb,
     ) -> Result<Vec<FirestoreListenerTargetParams>, FirestoreError> {
-        let read_from_time = crate::cache::cache_target_read_time();
+        let read_from_time = FirestoreCacheCollectionConfiguration::listener_read_time();
 
         self.preload_collections(db).await?;
 
@@ -560,7 +560,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
                 } else {
                     None
                 };
-                crate::cache::target_params_for_collection(collection_config, resume_type)
+                collection_config.listener_target_params(resume_type)
             })
             .collect())
     }
@@ -600,7 +600,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
     ) -> FirestoreResult<FirestoreListenerTargetParams> {
         // Captured before reading anything, so that writes landing during the preload are still
         // delivered once the listener target attaches from this point in time.
-        let read_from_time = crate::cache::cache_target_read_time();
+        let read_from_time = FirestoreCacheCollectionConfiguration::listener_read_time();
         let collection_path = collection_config.resolve_collection_path(db.get_documents_path());
 
         // A collection added at runtime starts from nothing - `remove_collection` deletes the
@@ -622,10 +622,9 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
                     "Preloading watched documents has been finished.",
                 );
 
-                let target_params = crate::cache::target_params_for_collection(
-                    &collection_config,
-                    Some(FirestoreListenerTargetResumeType::ReadTime(read_from_time)),
-                );
+                let target_params = collection_config.listener_target_params(Some(
+                    FirestoreListenerTargetResumeType::ReadTime(read_from_time),
+                ));
                 let mut config = self
                     .config
                     .write()
@@ -667,10 +666,9 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
             );
         }
 
-        let target_params = crate::cache::target_params_for_collection(
-            &collection_config,
-            Some(FirestoreListenerTargetResumeType::ReadTime(read_from_time)),
-        );
+        let target_params = collection_config.listener_target_params(Some(
+            FirestoreListenerTargetResumeType::ReadTime(read_from_time),
+        ));
 
         // Published only now: until this point the collection does not exist as far as reads are
         // concerned, so no listing can see it half filled.
@@ -794,7 +792,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
                 Ok(())
             }
             FirestoreListenEvent::TargetChange(ref target_change) => {
-                match crate::cache::cache_target_change_action(&self.config(), target_change) {
+                match self.config().target_change_action(target_change) {
                     crate::cache::FirestoreCacheTargetChangeAction::SuspendAndInvalidate(
                         invalidations,
                     ) => {
@@ -1129,10 +1127,7 @@ mod tests {
 
         // The target has to watch the named documents, not the whole collection: getting this
         // wrong subscribes to everything while looking correct from the outside.
-        let params = crate::cache::target_params_for_collection(
-            &config.collections[&format!("{DOCS}/a")],
-            None,
-        );
+        let params = config.collections[&format!("{DOCS}/a")].listener_target_params(None);
         match params.target_type {
             FirestoreTargetType::Documents(documents) => {
                 assert_eq!(documents.collection, "a");

--- a/src/cache/backends/persistent_backend.rs
+++ b/src/cache/backends/persistent_backend.rs
@@ -162,6 +162,14 @@ impl FirestorePersistentCacheBackend {
             .is_some()
     }
 
+    /// Stops a collection answering `list`/`query` until Firestore reports it consistent again.
+    fn suspend_collection(&self, collection_path: &str) {
+        self.suspended_collections
+            .write()
+            .expect("cache suspended collections lock poisoned")
+            .insert(collection_path.to_string());
+    }
+
     /// Whether a collection is mid-replay after Firestore reset or removed its listener target.
     fn is_suspended(&self, collection_path: &str) -> bool {
         self.suspended_collections
@@ -725,6 +733,29 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
             .remove(collection_path);
 
         Ok(Some(removed.listener_target))
+    }
+
+    async fn begin_collection_resync(&self, collection_path: &str) -> FirestoreResult<()> {
+        if !self.config().collections.contains_key(collection_path) {
+            return Ok(());
+        }
+        self.suspend_collection(collection_path);
+        self.invalidate_collection(collection_path)?;
+        Ok(())
+    }
+
+    async fn authoritative_doc_count(&self, collection_path: &str) -> FirestoreResult<Option<u64>> {
+        // redb holds exactly what was written, with no eviction of its own, so a preloaded
+        // collection's row count is the server's count.
+        let config = self.config();
+        let Some(collection_config) = config.collections.get(collection_path) else {
+            return Ok(None);
+        };
+        if !collection_config.collection_load_mode.is_preloading() || !self.is_open() {
+            return Ok(None);
+        }
+
+        Ok(self.table_len(collection_path).ok())
     }
 
     async fn shutdown(&self) -> Result<(), FirestoreError> {

--- a/src/cache/backends/persistent_backend.rs
+++ b/src/cache/backends/persistent_backend.rs
@@ -4,12 +4,11 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 
 use crate::cache::cache_query_engine::FirestoreCacheQueryEngine;
-use crate::FirestoreInstant;
 use futures::StreamExt;
 use gcloud_sdk::google::firestore::v1::Document;
 use gcloud_sdk::prost::Message;
 use redb::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::*;
@@ -546,7 +545,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
         _options: &FirestoreCacheOptions,
         db: &FirestoreDb,
     ) -> Result<Vec<FirestoreListenerTargetParams>, FirestoreError> {
-        let read_from_time = FirestoreInstant::now();
+        let read_from_time = crate::cache::cache_target_read_time();
 
         self.preload_collections(db).await?;
 
@@ -561,17 +560,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
                 } else {
                     None
                 };
-                FirestoreListenerTargetParams::new(
-                    collection_config.listener_target.clone(),
-                    FirestoreTargetType::Query(
-                        FirestoreQueryParams::new(
-                            collection_config.collection_name.as_str().into(),
-                        )
-                        .opt_parent(collection_config.parent.clone()),
-                    ),
-                    HashMap::new(),
-                )
-                .opt_resume_type(resume_type)
+                crate::cache::target_params_for_collection(collection_config, resume_type)
             })
             .collect())
     }
@@ -611,7 +600,7 @@ impl FirestoreCacheBackend for FirestorePersistentCacheBackend {
     ) -> FirestoreResult<FirestoreListenerTargetParams> {
         // Captured before reading anything, so that writes landing during the preload are still
         // delivered once the listener target attaches from this point in time.
-        let read_from_time = FirestoreInstant::now();
+        let read_from_time = crate::cache::cache_target_read_time();
         let collection_path = collection_config.resolve_collection_path(db.get_documents_path());
 
         // A collection added at runtime starts from nothing - `remove_collection` deletes the
@@ -1124,6 +1113,65 @@ mod tests {
             .expect("event handled");
 
         assert!(!cached(&backend, "a", "one").await);
+    }
+
+    #[tokio::test]
+    async fn a_documents_watch_builds_a_documents_target_and_is_not_listable() {
+        let config = FirestoreCacheConfiguration::new().add_collection_config_at(
+            DOCS,
+            FirestoreCacheCollectionConfiguration::new(
+                "a",
+                FirestoreListenerTarget::new(1000),
+                FirestoreCacheCollectionLoadMode::PreloadAllDocs,
+            )
+            .with_documents(["one", "two"]),
+        );
+
+        // The target has to watch the named documents, not the whole collection: getting this
+        // wrong subscribes to everything while looking correct from the outside.
+        let params = crate::cache::target_params_for_collection(
+            &config.collections[&format!("{DOCS}/a")],
+            None,
+        );
+        match params.target_type {
+            FirestoreTargetType::Documents(documents) => {
+                assert_eq!(documents.collection, "a");
+                assert_eq!(documents.documents, vec!["one", "two"]);
+            }
+            other => panic!("expected a documents target, got {other:?}"),
+        }
+
+        assert!(!config.is_collection_listable(&format!("{DOCS}/a")));
+    }
+
+    #[tokio::test]
+    async fn a_preloaded_collection_reports_a_comparable_document_count() {
+        let backend = preloaded(&[("a", 1000)]);
+        seed(&backend, "a", "one").await;
+        seed(&backend, "a", "two").await;
+
+        assert_eq!(
+            backend
+                .authoritative_doc_count(&format!("{DOCS}/a"))
+                .await
+                .unwrap(),
+            Some(2)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_shut_down_cache_reports_no_comparable_count() {
+        let backend = preloaded(&[("a", 1000)]);
+        seed(&backend, "a", "one").await;
+        backend.shutdown().await.unwrap();
+
+        assert_eq!(
+            backend
+                .authoritative_doc_count(&format!("{DOCS}/a"))
+                .await
+                .unwrap(),
+            None
+        );
     }
 
     #[tokio::test]

--- a/src/cache/builder.rs
+++ b/src/cache/builder.rs
@@ -124,6 +124,7 @@ pub struct FirestoreCacheCollection {
     parent: Option<String>,
     load_mode: FirestoreCacheCollectionLoadMode,
     listener_target: Option<u32>,
+    documents: Option<Vec<String>>,
 }
 
 impl FirestoreCacheCollection {
@@ -155,6 +156,7 @@ impl FirestoreCacheCollection {
             parent: None,
             load_mode,
             listener_target: None,
+            documents: None,
         }
     }
 
@@ -175,8 +177,12 @@ impl FirestoreCacheCollection {
             listener_target,
             self.load_mode,
         );
-        match self.parent {
+        let config = match self.parent {
             Some(parent) => config.with_parent(parent),
+            None => config,
+        };
+        match self.documents {
+            Some(document_ids) => config.with_documents(document_ids),
             None => config,
         }
     }
@@ -219,6 +225,39 @@ impl FirestoreCacheCollection {
         }
     }
 
+    /// Caches and listens to only these documents of the collection.
+    ///
+    /// The listener watches exactly these documents, so unrelated changes in the collection are
+    /// never streamed to your process. This is the shape to reach for when you cache a known set
+    /// of documents - configuration, feature flags, reference data - rather than a collection:
+    /// `.collection(name)` subscribes to the whole collection even when it does not preload it.
+    ///
+    /// Such a collection is never listable, whatever its load mode: it holds a chosen subset, so
+    /// `list` and `query` would return a partial answer that looks complete.
+    ///
+    /// ```rust,no_run
+    /// # use firestore::*;
+    /// let collection = FirestoreCacheCollection::new("configs")
+    ///     .documents(["site", "billing"])
+    ///     .preload_all();
+    /// ```
+    #[inline]
+    pub fn documents<I>(self, document_ids: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        Self {
+            documents: Some(
+                document_ids
+                    .into_iter()
+                    .map(|id| id.as_ref().to_string())
+                    .collect(),
+            ),
+            ..self
+        }
+    }
+
     /// Pins this collection to a specific Firestore listener target ID instead of an
     /// automatically assigned one.
     #[inline]
@@ -233,6 +272,7 @@ impl FirestoreCacheCollection {
 impl From<FirestoreCacheCollectionConfiguration> for FirestoreCacheCollection {
     fn from(config: FirestoreCacheCollectionConfiguration) -> Self {
         Self {
+            documents: config.watched_document_ids().map(|ids| ids.to_vec()),
             collection_name: config.collection_name,
             parent: config.parent,
             load_mode: config.collection_load_mode,
@@ -583,6 +623,9 @@ fn build_configuration(
         );
         if let Some(ref parent) = collection.parent {
             collection_config = collection_config.with_parent(parent);
+        }
+        if let Some(ref documents) = collection.documents {
+            collection_config = collection_config.with_documents(documents);
         }
 
         let collection_path = collection_config.resolve_collection_path(documents_path);

--- a/src/cache/builder.rs
+++ b/src/cache/builder.rs
@@ -127,13 +127,57 @@ pub struct FirestoreCacheCollection {
 }
 
 impl FirestoreCacheCollection {
+    /// Describes a collection to cache, filled lazily unless a preloading mode is chosen.
+    ///
+    /// This is what [`FirestoreCache::add_collection`](crate::FirestoreCache::add_collection)
+    /// takes; the builder has its own `collection` / `preloaded_collection` / `collection_with`
+    /// methods for describing collections up front.
+    ///
+    /// ```rust,no_run
+    /// # use firestore::*;
+    /// let collection = FirestoreCacheCollection::new("orders").preload_all();
+    /// ```
     #[inline]
-    fn new<S: AsRef<str>>(collection_name: S, load_mode: FirestoreCacheCollectionLoadMode) -> Self {
+    pub fn new<S: AsRef<str>>(collection_name: S) -> Self {
+        Self::with_load_mode(
+            collection_name,
+            FirestoreCacheCollectionLoadMode::PreloadNone,
+        )
+    }
+
+    #[inline]
+    pub(crate) fn with_load_mode<S: AsRef<str>>(
+        collection_name: S,
+        load_mode: FirestoreCacheCollectionLoadMode,
+    ) -> Self {
         Self {
             collection_name: collection_name.as_ref().to_string(),
             parent: None,
             load_mode,
             listener_target: None,
+        }
+    }
+
+    /// The listener target this collection was pinned to, if any.
+    #[inline]
+    pub(crate) fn requested_listener_target(&self) -> Option<u32> {
+        self.listener_target
+    }
+
+    /// Turns this description into a configuration entry using the given listener target.
+    #[inline]
+    pub(crate) fn into_configuration(
+        self,
+        listener_target: FirestoreListenerTarget,
+    ) -> FirestoreCacheCollectionConfiguration {
+        let config = FirestoreCacheCollectionConfiguration::new(
+            &self.collection_name,
+            listener_target,
+            self.load_mode,
+        );
+        match self.parent {
+            Some(parent) => config.with_parent(parent),
+            None => config,
         }
     }
 
@@ -269,20 +313,22 @@ where
     /// Use [`preloaded_collection`](Self::preloaded_collection) if you need cached listings.
     #[inline]
     pub fn collection<S: AsRef<str>>(mut self, collection_name: S) -> Self {
-        self.collections.push(FirestoreCacheCollection::new(
-            collection_name,
-            FirestoreCacheCollectionLoadMode::PreloadNone,
-        ));
+        self.collections
+            .push(FirestoreCacheCollection::with_load_mode(
+                collection_name,
+                FirestoreCacheCollectionLoadMode::PreloadNone,
+            ));
         self
     }
 
     /// Caches a complete copy of a collection, so that `list` and `query` can be served from it.
     #[inline]
     pub fn preloaded_collection<S: AsRef<str>>(mut self, collection_name: S) -> Self {
-        self.collections.push(FirestoreCacheCollection::new(
-            collection_name,
-            K::default_preload_mode(),
-        ));
+        self.collections
+            .push(FirestoreCacheCollection::with_load_mode(
+                collection_name,
+                K::default_preload_mode(),
+            ));
         self
     }
 
@@ -304,10 +350,11 @@ where
         S: AsRef<str>,
         F: FnOnce(FirestoreCacheCollection) -> FirestoreCacheCollection,
     {
-        self.collections.push(f(FirestoreCacheCollection::new(
-            collection_name,
-            FirestoreCacheCollectionLoadMode::PreloadNone,
-        )));
+        self.collections
+            .push(f(FirestoreCacheCollection::with_load_mode(
+                collection_name,
+                FirestoreCacheCollectionLoadMode::PreloadNone,
+            )));
         self
     }
 
@@ -474,16 +521,8 @@ fn build_configuration(
     collections: &[FirestoreCacheCollection],
     incomplete_collection_policy: FirestoreCacheIncompleteCollectionPolicy,
 ) -> FirestoreResult<FirestoreCacheConfiguration> {
-    if collections.is_empty() {
-        return Err(FirestoreError::InvalidParametersError(
-            FirestoreInvalidParametersError::new(FirestoreInvalidParametersPublicDetails::new(
-                "collections".into(),
-                "A cache must be configured with at least one collection. Add one with \
-                 `.collection(..)` or `.preloaded_collection(..)`."
-                    .into(),
-            )),
-        ));
-    }
+    // An empty cache is allowed: collections can be added at runtime with
+    // `FirestoreCache::add_collection`.
 
     // Explicitly requested targets are reserved first, so that automatic assignment can route
     // around them regardless of the order collections were added in.
@@ -572,7 +611,10 @@ mod tests {
     const DOCS: &str = "projects/test/databases/(default)/documents";
 
     fn lazy(name: &str) -> FirestoreCacheCollection {
-        FirestoreCacheCollection::new(name, FirestoreCacheCollectionLoadMode::PreloadNone)
+        FirestoreCacheCollection::with_load_mode(
+            name,
+            FirestoreCacheCollectionLoadMode::PreloadNone,
+        )
     }
 
     fn target_of(config: &FirestoreCacheConfiguration, path: &str) -> u32 {
@@ -649,16 +691,16 @@ mod tests {
     }
 
     #[test]
-    fn rejects_an_empty_collection_list() {
-        let err = build_configuration(
+    fn allows_an_empty_collection_list_for_a_cache_filled_at_runtime() {
+        let config = build_configuration(
             DOCS,
             1000,
             &[],
             FirestoreCacheIncompleteCollectionPolicy::default(),
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert!(matches!(err, FirestoreError::InvalidParametersError(_)));
+        assert!(config.collections.is_empty());
     }
 
     #[test]

--- a/src/cache/configuration.rs
+++ b/src/cache/configuration.rs
@@ -71,6 +71,19 @@ impl FirestoreCacheConfiguration {
         self
     }
 
+    /// Whether the cache holds this document: its collection is cached, and the collection is not
+    /// restricted to a different set of document IDs.
+    #[inline]
+    pub fn is_document_cached(&self, collection_path: &str, document_id: &str) -> bool {
+        match self.collections.get(collection_path) {
+            Some(config) => match config.watched_document_ids() {
+                Some(document_ids) => document_ids.iter().any(|id| id == document_id),
+                None => true,
+            },
+            None => false,
+        }
+    }
+
     /// Returns the first listener target ID at or above `from` that no collection uses.
     ///
     /// Shared by the builder's up-front assignment and by adding a collection at runtime, so the
@@ -123,7 +136,7 @@ impl FirestoreCacheConfiguration {
         self.collections
             .iter()
             .find(|(_, config)| config.listener_target == *target)
-            .map(|(collection_path, _)| FirestoreCacheTargetScope::Collection(collection_path))
+            .map(|(collection_path, config)| target_scope_of(collection_path, config))
     }
 
     /// Returns what every listener target of this cache covers.
@@ -132,8 +145,8 @@ impl FirestoreCacheConfiguration {
     #[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
     pub(crate) fn all_target_scopes(&self) -> Vec<FirestoreCacheTargetScope<'_>> {
         self.collections
-            .keys()
-            .map(|collection_path| FirestoreCacheTargetScope::Collection(collection_path))
+            .iter()
+            .map(|(collection_path, config)| target_scope_of(collection_path, config))
             .collect()
     }
 
@@ -151,6 +164,9 @@ impl FirestoreCacheConfiguration {
     #[inline]
     pub fn is_collection_listable(&self, collection_path: &str) -> bool {
         match self.collections.get(collection_path) {
+            // A collection watched by document ID holds only those documents, however it is
+            // loaded, so it can never answer a listing of the collection completely.
+            Some(config) if config.watched_document_ids().is_some() => false,
             Some(config) => match self.incomplete_collection_policy {
                 FirestoreCacheIncompleteCollectionPolicy::SkipCache => {
                     config.collection_load_mode.is_preloading()
@@ -169,6 +185,46 @@ impl Default for FirestoreCacheConfiguration {
     }
 }
 
+/// Which documents of a collection the cache holds and listens to.
+///
+/// This is independent of [`FirestoreCacheCollectionLoadMode`]: that decides *when* documents are
+/// fetched, this decides *which* ones exist as far as the cache is concerned.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum FirestoreCacheCollectionWatch {
+    /// Listen to every document in the collection. The default.
+    WholeCollection,
+    /// Listen only to these document IDs.
+    ///
+    /// The listener watches exactly these documents rather than the whole collection, so unrelated
+    /// changes are never streamed to your process or written into the cache. Such a collection is
+    /// never listable: it holds a chosen subset, so answering `list` or `query` from it would
+    /// return a partial result that looks complete.
+    Documents(Vec<String>),
+}
+
+impl Default for FirestoreCacheCollectionWatch {
+    #[inline]
+    fn default() -> Self {
+        Self::WholeCollection
+    }
+}
+
+/// The scope of the listener target that keeps one cached collection up to date.
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+#[inline]
+pub(crate) fn target_scope_of<'a>(
+    collection_path: &'a str,
+    config: &'a FirestoreCacheCollectionConfiguration,
+) -> FirestoreCacheTargetScope<'a> {
+    match config.watched_document_ids() {
+        Some(document_ids) => FirestoreCacheTargetScope::Documents {
+            collection_path,
+            document_ids,
+        },
+        None => FirestoreCacheTargetScope::Collection(collection_path),
+    }
+}
+
 /// What a Firestore listener target of this cache covers.
 ///
 /// Every cached target is currently a whole-collection query, so only
@@ -181,7 +237,6 @@ pub(crate) enum FirestoreCacheTargetScope<'a> {
     /// The target covers every document in the collection at this path.
     Collection(&'a str),
     /// The target covers only these document IDs within the collection at this path.
-    #[allow(dead_code)]
     Documents {
         collection_path: &'a str,
         document_ids: &'a [String],
@@ -233,6 +288,8 @@ pub struct FirestoreCacheCollectionConfiguration {
     /// How this collection is populated at startup, which also determines whether `list`/`query`
     /// may be served from the cache.
     pub collection_load_mode: FirestoreCacheCollectionLoadMode,
+    /// Which documents of the collection the cache holds and listens to.
+    pub collection_watch: FirestoreCacheCollectionWatch,
     #[doc(hidden)]
     /// Not implemented and has no effect. Scheduled for removal.
     pub indices: Vec<FirestoreCacheIndexConfiguration>,
@@ -254,7 +311,35 @@ impl FirestoreCacheCollectionConfiguration {
             parent: None,
             listener_target,
             collection_load_mode,
+            collection_watch: FirestoreCacheCollectionWatch::WholeCollection,
             indices: Vec::new(),
+        }
+    }
+
+    /// Caches and listens to only these documents of the collection, instead of all of them.
+    #[inline]
+    pub fn with_documents<I>(self, document_ids: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        Self {
+            collection_watch: FirestoreCacheCollectionWatch::Documents(
+                document_ids
+                    .into_iter()
+                    .map(|id| id.as_ref().to_string())
+                    .collect(),
+            ),
+            ..self
+        }
+    }
+
+    /// The document IDs this collection is limited to, if any.
+    #[inline]
+    pub fn watched_document_ids(&self) -> Option<&[String]> {
+        match &self.collection_watch {
+            FirestoreCacheCollectionWatch::WholeCollection => None,
+            FirestoreCacheCollectionWatch::Documents(ids) => Some(ids),
         }
     }
 

--- a/src/cache/configuration.rs
+++ b/src/cache/configuration.rs
@@ -71,6 +71,20 @@ impl FirestoreCacheConfiguration {
         self
     }
 
+    /// Decides what a Firestore target change means for the collections of this cache.
+    ///
+    /// A backend's [`on_listen_event`](crate::FirestoreCacheBackend::on_listen_event) should act on
+    /// this rather than interpreting the target change itself: it resolves Firestore's "empty
+    /// target IDs means all targets" rule, and scopes the result to the documents a target actually
+    /// covers.
+    #[inline]
+    pub fn target_change_action(
+        &self,
+        target_change: &gcloud_sdk::google::firestore::v1::TargetChange,
+    ) -> crate::FirestoreCacheTargetChangeAction {
+        crate::cache::cache_target_change_action(self, target_change)
+    }
+
     /// Whether the cache holds this document: its collection is cached, and the collection is not
     /// restricted to a different set of document IDs.
     #[inline]
@@ -128,7 +142,6 @@ impl FirestoreCacheConfiguration {
     ///
     /// Used to scope the invalidation when Firestore resets or removes a target. A linear scan is
     /// deliberate: the map is small, and this runs only on target changes, never per document.
-    #[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
     pub(crate) fn target_scope(
         &self,
         target: &FirestoreListenerTarget,
@@ -142,7 +155,6 @@ impl FirestoreCacheConfiguration {
     /// Returns what every listener target of this cache covers.
     ///
     /// Firestore uses an empty set of target IDs to mean "all targets", which is what this is for.
-    #[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
     pub(crate) fn all_target_scopes(&self) -> Vec<FirestoreCacheTargetScope<'_>> {
         self.collections
             .iter()
@@ -210,7 +222,6 @@ impl Default for FirestoreCacheCollectionWatch {
 }
 
 /// The scope of the listener target that keeps one cached collection up to date.
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 #[inline]
 pub(crate) fn target_scope_of<'a>(
     collection_path: &'a str,
@@ -231,7 +242,6 @@ pub(crate) fn target_scope_of<'a>(
 /// [`Collection`](Self::Collection) is produced today. Invalidation is written against this rather
 /// than against a bare collection path so that a target watching a handful of documents does not
 /// end up wiping the entire collection.
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) enum FirestoreCacheTargetScope<'a> {
     /// The target covers every document in the collection at this path.
@@ -243,7 +253,6 @@ pub(crate) enum FirestoreCacheTargetScope<'a> {
     },
 }
 
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 impl FirestoreCacheTargetScope<'_> {
     /// The collection this scope belongs to.
     #[inline]
@@ -314,6 +323,29 @@ impl FirestoreCacheCollectionConfiguration {
             collection_watch: FirestoreCacheCollectionWatch::WholeCollection,
             indices: Vec::new(),
         }
+    }
+
+    /// The listener target that keeps this collection up to date.
+    ///
+    /// Backends use this in [`load`](crate::FirestoreCacheBackend::load) so that a collection
+    /// limited to named documents is listened to as a documents target rather than as a query over
+    /// the whole collection.
+    #[inline]
+    pub fn listener_target_params(
+        &self,
+        resume_type: Option<crate::FirestoreListenerTargetResumeType>,
+    ) -> crate::FirestoreListenerTargetParams {
+        crate::cache::target_params_for_collection(self, resume_type)
+    }
+
+    /// The point in time a newly attached listener target should be resumed from.
+    ///
+    /// Deliberately a little behind the local clock: a read time in the server's future is rejected
+    /// as invalid, and a client clock can easily run slightly ahead. The cost is a few redundant
+    /// document changes, which are idempotent.
+    #[inline]
+    pub fn listener_read_time() -> crate::FirestoreInstant {
+        crate::cache::cache_target_read_time()
     }
 
     /// Caches and listens to only these documents of the collection, instead of all of them.

--- a/src/cache/configuration.rs
+++ b/src/cache/configuration.rs
@@ -1,4 +1,8 @@
-use crate::{FirestoreDb, FirestoreListenerTarget};
+use crate::errors::{
+    FirestoreError, FirestoreInvalidParametersError, FirestoreInvalidParametersPublicDetails,
+};
+use crate::{FirestoreDb, FirestoreListenerTarget, FirestoreResult};
+use rvstruct::ValueStruct;
 use std::collections::HashMap;
 
 /// Describes which collections a [`FirestoreCache`](crate::FirestoreCache) holds and how each of
@@ -67,6 +71,72 @@ impl FirestoreCacheConfiguration {
         self
     }
 
+    /// Returns the first listener target ID at or above `from` that no collection uses.
+    ///
+    /// Shared by the builder's up-front assignment and by adding a collection at runtime, so the
+    /// two cannot drift apart.
+    pub(crate) fn allocate_listener_target(
+        &self,
+        from: u32,
+    ) -> FirestoreResult<FirestoreListenerTarget> {
+        let used: std::collections::HashSet<u32> = self
+            .collections
+            .values()
+            .map(|config| *config.listener_target.value())
+            .collect();
+
+        let mut candidate = from.max(1);
+        while used.contains(&candidate) {
+            candidate = candidate.checked_add(1).ok_or_else(|| {
+                FirestoreError::InvalidParametersError(FirestoreInvalidParametersError::new(
+                    FirestoreInvalidParametersPublicDetails::new(
+                        "listener_target".into(),
+                        "Ran out of listener target IDs while assigning them automatically.".into(),
+                    ),
+                ))
+            })?;
+        }
+
+        let target = FirestoreListenerTarget::new(candidate);
+        target.validate()?;
+        Ok(target)
+    }
+
+    /// The highest listener target ID in use, if any.
+    pub(crate) fn max_listener_target(&self) -> Option<u32> {
+        self.collections
+            .values()
+            .map(|config| *config.listener_target.value())
+            .max()
+    }
+
+    /// Returns what a listener target covers, or `None` if the target does not belong to this
+    /// cache.
+    ///
+    /// Used to scope the invalidation when Firestore resets or removes a target. A linear scan is
+    /// deliberate: the map is small, and this runs only on target changes, never per document.
+    #[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+    pub(crate) fn target_scope(
+        &self,
+        target: &FirestoreListenerTarget,
+    ) -> Option<FirestoreCacheTargetScope<'_>> {
+        self.collections
+            .iter()
+            .find(|(_, config)| config.listener_target == *target)
+            .map(|(collection_path, _)| FirestoreCacheTargetScope::Collection(collection_path))
+    }
+
+    /// Returns what every listener target of this cache covers.
+    ///
+    /// Firestore uses an empty set of target IDs to mean "all targets", which is what this is for.
+    #[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+    pub(crate) fn all_target_scopes(&self) -> Vec<FirestoreCacheTargetScope<'_>> {
+        self.collections
+            .keys()
+            .map(|collection_path| FirestoreCacheTargetScope::Collection(collection_path))
+            .collect()
+    }
+
     /// Returns `true` when the cache is configured to hold a *complete* copy of the collection at
     /// `collection_path`, meaning `list` and `query` requests may be served from the cache.
     ///
@@ -96,6 +166,39 @@ impl Default for FirestoreCacheConfiguration {
     #[inline]
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// What a Firestore listener target of this cache covers.
+///
+/// Every cached target is currently a whole-collection query, so only
+/// [`Collection`](Self::Collection) is produced today. Invalidation is written against this rather
+/// than against a bare collection path so that a target watching a handful of documents does not
+/// end up wiping the entire collection.
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) enum FirestoreCacheTargetScope<'a> {
+    /// The target covers every document in the collection at this path.
+    Collection(&'a str),
+    /// The target covers only these document IDs within the collection at this path.
+    #[allow(dead_code)]
+    Documents {
+        collection_path: &'a str,
+        document_ids: &'a [String],
+    },
+}
+
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+impl FirestoreCacheTargetScope<'_> {
+    /// The collection this scope belongs to.
+    #[inline]
+    pub(crate) fn collection_path(&self) -> &str {
+        match self {
+            Self::Collection(collection_path) => collection_path,
+            Self::Documents {
+                collection_path, ..
+            } => collection_path,
+        }
     }
 }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -776,7 +776,6 @@ pub trait FirestoreCacheBackend: FirestoreCacheDocsByPathSupport {
 ///
 /// A target whose count keeps disagreeing with Firestore would otherwise re-download its
 /// collection in a loop.
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 const FIRESTORE_CACHE_MIN_RESYNC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Applies listen events to a cache backend, and acts on the ones that say the cache has diverged.
@@ -994,14 +993,12 @@ where
 /// A resume `read_time` in the server's future is rejected as invalid, and the client's clock can
 /// easily be a little ahead. The cost of the margin is a few redundant document changes, which are
 /// idempotent; the cost of being wrong the other way is a rejected listen request.
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 const FIRESTORE_CACHE_READ_TIME_SKEW_MARGIN: std::time::Duration =
     std::time::Duration::from_secs(5);
 
 /// The point in time a newly attached target should be resumed from.
 ///
 /// Deliberately a little in the past - see [`FIRESTORE_CACHE_READ_TIME_SKEW_MARGIN`].
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 pub(crate) fn cache_target_read_time() -> FirestoreInstant {
     let now = FirestoreInstant::now();
     jiff::SignedDuration::try_from(FIRESTORE_CACHE_READ_TIME_SKEW_MARGIN)
@@ -1014,7 +1011,6 @@ pub(crate) fn cache_target_read_time() -> FirestoreInstant {
 ///
 /// Shared by the backends and by their runtime `add_collection`, so that a collection added later
 /// is listened to exactly like one configured up front.
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 pub(crate) fn target_params_for_collection(
     collection_config: &FirestoreCacheCollectionConfiguration,
     resume_type: Option<FirestoreListenerTargetResumeType>,
@@ -1058,8 +1054,7 @@ pub(crate) fn cache_dynamic_collections_unsupported_error(operation: &str) -> Fi
 ///
 /// Firestore uses an empty set of target IDs to mean *all* targets, which this resolves for the
 /// caller.
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
-pub(crate) enum FirestoreCacheTargetChangeAction {
+pub enum FirestoreCacheTargetChangeAction {
     /// The listener targets are being replayed from scratch: drop what is cached for them and stop
     /// answering `list`/`query` from their collections until the replay completes.
     SuspendAndInvalidate(Vec<FirestoreCacheInvalidation>),
@@ -1071,9 +1066,8 @@ pub(crate) enum FirestoreCacheTargetChangeAction {
 }
 
 /// What one target change asks the backend to drop.
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) enum FirestoreCacheInvalidation {
+pub enum FirestoreCacheInvalidation {
     /// Drop every document cached for this collection.
     Collection(String),
     /// Drop only these documents of the collection - the target watches nothing else, so wiping
@@ -1084,9 +1078,9 @@ pub(crate) enum FirestoreCacheInvalidation {
     },
 }
 
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 impl FirestoreCacheInvalidation {
-    pub(crate) fn collection_path(&self) -> &str {
+    /// The collection this invalidation belongs to.
+    pub fn collection_path(&self) -> &str {
         match self {
             Self::Collection(collection_path) => collection_path,
             Self::Documents {
@@ -1099,8 +1093,8 @@ impl FirestoreCacheInvalidation {
 /// Decides what a target change means for the cache.
 ///
 /// Shared by the backends so that they cannot drift apart, and kept free of any backend state so
-/// that it can be unit tested on its own.
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+/// that it can be unit tested on its own. Reachable publicly as
+/// [`FirestoreCacheConfiguration::target_change_action`].
 pub(crate) fn cache_target_change_action(
     config: &FirestoreCacheConfiguration,
     target_change: &gcloud_sdk::google::firestore::v1::TargetChange,
@@ -1143,7 +1137,6 @@ pub(crate) fn cache_target_change_action(
     }
 }
 
-#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 fn affected_scopes<'a>(
     config: &'a FirestoreCacheConfiguration,
     target_ids: &[i32],

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -237,6 +237,11 @@ where
     pub listener: tokio::sync::Mutex<FirestoreListener<FirestoreDb, LS>>,
     /// A clone of the Firestore database client.
     pub db: FirestoreDb,
+    /// Serialises adding and removing collections.
+    ///
+    /// Without it two concurrent `add_collection` calls could both pass the "already cached" check
+    /// before either published its entry, leaving one of the two listener targets orphaned.
+    pub collection_mutations: tokio::sync::Mutex<()>,
     /// The next listener target ID to hand out to a collection added at runtime.
     ///
     /// Monotonic on purpose: an ID freed by `remove_collection` is never reissued in this process,
@@ -429,6 +434,7 @@ where
                 backend: Arc::new(backend),
                 listener: tokio::sync::Mutex::new(listener),
                 db: db.clone(),
+                collection_mutations: tokio::sync::Mutex::new(()),
                 next_listener_target: std::sync::Mutex::new(next_listener_target),
             },
         })
@@ -526,6 +532,8 @@ where
         &self,
         collection: FirestoreCacheCollection,
     ) -> FirestoreResult<()> {
+        let _mutation = self.inner.collection_mutations.lock().await;
+
         let documents_path = self.inner.db.get_documents_path();
         let config = self.inner.backend.cache_configuration();
 
@@ -823,6 +831,17 @@ where
                 return;
             }
             FirestoreListenEvent::TargetChange(target_change) => {
+                // A reset or removed target is about to be replayed, so a filter counting the copy
+                // we are dropping says nothing about the copy that replaces it.
+                if matches!(
+                    FirestoreListenerTargetChangeType::try_from(target_change.target_change_type),
+                    Ok(FirestoreListenerTargetChangeType::Reset)
+                        | Ok(FirestoreListenerTargetChangeType::Remove)
+                ) {
+                    self.discard_pending_filters(&target_change.target_ids)
+                        .await;
+                }
+
                 // NO_CHANGE and CURRENT with a read time are the snapshot boundaries.
                 let settles_snapshot = matches!(
                     FirestoreListenerTargetChangeType::try_from(target_change.target_change_type),
@@ -838,6 +857,21 @@ where
 
         if let Err(err) = self.backend.on_listen_event(event).await {
             error!(?err, "Error occurred while updating cache.");
+        }
+    }
+
+    /// Forgets the filters waiting on targets whose contents are being thrown away anyway.
+    async fn discard_pending_filters(&self, target_ids: &[i32]) {
+        let mut state = self.state.lock().await;
+        if target_ids.is_empty() {
+            state.pending_filters.clear();
+            return;
+        }
+        for target in target_ids
+            .iter()
+            .filter_map(|id| FirestoreListenerTarget::try_from(*id).ok())
+        {
+            state.pending_filters.remove(&target);
         }
     }
 
@@ -936,10 +970,44 @@ where
             "The cache holds a different number of documents than Firestore reports, so it has              missed changes. Resynchronising the collection.",
         );
 
-        // The listener discards the target's resume state and reopens the stream; Firestore then
-        // replays the collection, and the reset that arrives with it empties the stale copy.
+        // Drop the stale copy first. Firestore replays a target that is re-added without a resume
+        // token, but a replay only says which documents exist - never which ones no longer do - so
+        // without this the documents whose deletion we missed would survive the resync, and the
+        // count would keep disagreeing.
+        if let Err(err) = self.backend.begin_collection_resync(collection_path).await {
+            error!(
+                ?err,
+                collection_path,
+                "Could not drop a diverged collection, so it was not resynchronised."
+            );
+            return;
+        }
+
+        // The listener then discards the target's resume state and reopens the stream. The
+        // collection serves listings again once Firestore reports the target current.
         self.listener.resync_target(target);
     }
+}
+
+/// How far back a target's read time is set from the local clock.
+///
+/// A resume `read_time` in the server's future is rejected as invalid, and the client's clock can
+/// easily be a little ahead. The cost of the margin is a few redundant document changes, which are
+/// idempotent; the cost of being wrong the other way is a rejected listen request.
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+const FIRESTORE_CACHE_READ_TIME_SKEW_MARGIN: std::time::Duration =
+    std::time::Duration::from_secs(5);
+
+/// The point in time a newly attached target should be resumed from.
+///
+/// Deliberately a little in the past - see [`FIRESTORE_CACHE_READ_TIME_SKEW_MARGIN`].
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+pub(crate) fn cache_target_read_time() -> FirestoreInstant {
+    let now = FirestoreInstant::now();
+    jiff::SignedDuration::try_from(FIRESTORE_CACHE_READ_TIME_SKEW_MARGIN)
+        .ok()
+        .and_then(|margin| now.checked_sub(margin).ok())
+        .unwrap_or(now)
 }
 
 /// Builds the listener target that keeps one cached collection up to date.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -72,16 +72,52 @@
 //! # Consistency
 //!
 //! Cached results are **eventually consistent**. They reflect the last state the listener
-//! delivered, so a write may take a moment to appear, and a stalled or reset listener can leave
-//! the cache stale without saying so. Cached listings are never *partial* by construction, but
-//! they are not guaranteed to be current. Do not cache data that must be read at strong
-//! consistency - read that through Firestore directly, or inside a transaction.
+//! delivered, so a write may take a moment to appear. Cached listings are never *partial* by
+//! construction, but they are not guaranteed to be current. Do not cache data that must be read at
+//! strong consistency - read that through Firestore directly, or inside a transaction.
+//!
+//! When Firestore resets or removes a listener target - after a reconnect, or when a stored resume
+//! token has expired - the cache drops what it holds for that collection and Firestore replays it.
+//! While that replay is in progress the collection stops answering `list` and `query` from the
+//! cache, because what it holds in the meantime is a partial view that would otherwise look like a
+//! complete one. `read_through_cache` falls back to Firestore for the duration;
+//! `read_cached_only` returns a [`FirestoreError::CacheError`](crate::errors::FirestoreError::CacheError).
+//! Reads by ID are unaffected beyond behaving like a cache miss.
+//!
+//! # Changing the cached collections at runtime
+//!
+//! The set of cached collections does not have to be fixed when the cache is built:
+//!
+//! ```rust,no_run
+//! # use firestore::*;
+//! # async fn example(cache: &FirestoreMemoryCache) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//! cache
+//!     .add_collection(FirestoreCacheCollection::new("currencies").preload_all())
+//!     .await?;
+//!
+//! cache.remove_collection("currencies").await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`FirestoreCache::add_collection`] downloads the collection first if it is preloaded, publishes
+//! it only once it is complete, and then extends the listener - so a listing never observes it half
+//! filled, and nothing written during the download is missed.
+//! [`FirestoreCache::remove_collection`] does the reverse, and also forgets the collection's resume
+//! token so its listener target ID cannot be reused against a different query.
+//!
+//! `FirestoreDb` handles created earlier with [`FirestoreDb::read_through_cache`] or
+//! [`FirestoreDb::read_cached_only`] pick both up immediately: they share the cache's backend
+//! rather than a copy of it. A cache can also be built with no collections at all and populated
+//! entirely at runtime.
 //!
 //! # Lifecycle
 //!
 //! [`FirestoreCacheBuilder::build`] creates the cache, preloads it and starts the listener. Call
-//! [`FirestoreCache::shutdown`] when you are done. Because `load` and `shutdown` take `&self`, a
-//! built cache can be shared as `Arc<FirestoreMemoryCache>` in your application state.
+//! [`FirestoreCache::shutdown`] when you are done - it stops the listener and releases the
+//! backend's resources, dropping the cached documents and, for the persistent backend, closing its
+//! database file. Because `load` and `shutdown` take `&self`, a built cache can be shared as
+//! `Arc<FirestoreMemoryCache>` in your application state.
 //!
 //! # Custom backends
 //!
@@ -169,6 +205,11 @@ where
     pub listener: tokio::sync::Mutex<FirestoreListener<FirestoreDb, LS>>,
     /// A clone of the Firestore database client.
     pub db: FirestoreDb,
+    /// The next listener target ID to hand out to a collection added at runtime.
+    ///
+    /// Monotonic on purpose: an ID freed by `remove_collection` is never reissued in this process,
+    /// so a resume token that outlived its target cannot be applied to a different query.
+    pub next_listener_target: std::sync::Mutex<u32>,
 }
 
 /// A ready-to-use in-memory cache.
@@ -344,12 +385,19 @@ where
             db.create_listener(listener_storage).await?
         };
 
+        let next_listener_target = backend
+            .cache_configuration()
+            .max_listener_target()
+            .map(|max| max.saturating_add(1))
+            .unwrap_or(FIRESTORE_CACHE_DEFAULT_LISTENER_TARGET_BASE);
+
         Ok(Self {
             inner: FirestoreCacheInner {
                 options,
                 backend: Arc::new(backend),
                 listener: tokio::sync::Mutex::new(listener),
                 db: db.clone(),
+                next_listener_target: std::sync::Mutex::new(next_listener_target),
             },
         })
     }
@@ -396,7 +444,17 @@ where
         Ok(())
     }
 
-    /// Shuts down the Firestore listener and the cache backend.
+    /// Shuts down the Firestore listener and releases the cache backend's resources.
+    ///
+    /// The in-memory backend drops its cached documents; the persistent backend closes its
+    /// database, releasing the exclusive lock on the file so that another cache can be opened over
+    /// the same directory. This happens here rather than on drop because handles to the backend
+    /// outlive the cache - [`read_through_cache`](crate::FirestoreDb::read_through_cache) clones
+    /// one into every `FirestoreDb` it is attached to.
+    ///
+    /// Reads through a cache that has been shut down do not fail: they behave as a cache miss, so
+    /// `read_through_cache` falls back to Firestore. `read_cached_only` reports the miss as an
+    /// error, as it does for anything else it cannot answer.
     ///
     /// # Returns
     /// A `Result` indicating success or failure.
@@ -404,6 +462,130 @@ where
         self.inner.listener.lock().await.shutdown().await?;
         self.inner.backend.shutdown().await?;
         Ok(())
+    }
+
+    /// Starts caching a collection on a running cache, without rebuilding it.
+    ///
+    /// The collection is downloaded first if it is configured to be preloaded, and only becomes
+    /// visible to readers once it is fully populated - so a listing never sees it half filled.
+    /// The listener then picks it up from the moment the download started, so nothing written in
+    /// the meantime is missed.
+    ///
+    /// `FirestoreDb` handles created earlier with
+    /// [`read_through_cache`](crate::FirestoreDb::read_through_cache) or
+    /// [`read_cached_only`](crate::FirestoreDb::read_cached_only) see the new collection
+    /// immediately: they share this cache's backend rather than a copy of it.
+    ///
+    /// ```rust,no_run
+    /// # use firestore::*;
+    /// # async fn example(cache: &FirestoreMemoryCache) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// cache
+    ///     .add_collection(FirestoreCacheCollection::new("currencies").preload_all())
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Returns an error if the collection is already cached, or if the backend does not support
+    /// changing its collections at runtime.
+    pub async fn add_collection(
+        &self,
+        collection: FirestoreCacheCollection,
+    ) -> FirestoreResult<()> {
+        let documents_path = self.inner.db.get_documents_path();
+        let config = self.inner.backend.cache_configuration();
+
+        let listener_target = match collection.requested_listener_target() {
+            Some(target) => {
+                let target = FirestoreListenerTarget::new(target);
+                target.validate()?;
+                target
+            }
+            None => {
+                // Never reuse an ID freed by `remove_collection`: a resume token belongs to one
+                // target's query, so handing the ID to a different one would resume it wrongly.
+                let mut next = self
+                    .inner
+                    .next_listener_target
+                    .lock()
+                    .expect("cache listener target counter poisoned");
+                let allocated = config.allocate_listener_target(*next)?;
+                *next = allocated.value().saturating_add(1);
+                allocated
+            }
+        };
+
+        let collection_config = collection.into_configuration(listener_target);
+        let collection_path = collection_config.resolve_collection_path(documents_path);
+
+        if config.collections.contains_key(&collection_path) {
+            return Err(FirestoreError::CacheError(FirestoreCacheError::new(
+                FirestoreErrorPublicGenericDetails::new("CacheCollectionAlreadyCached".into()),
+                format!("The collection `{collection_path}` is already cached."),
+            )));
+        }
+
+        let target_params = self
+            .inner
+            .backend
+            .add_collection(&self.inner.options, &self.inner.db, collection_config)
+            .await?;
+
+        self.inner.listener.lock().await.add_target(target_params)?;
+
+        info!(collection_path, "Added a collection to the cache.");
+        Ok(())
+    }
+
+    /// Stops caching a collection, drops its documents and stops listening to it.
+    ///
+    /// Returns `false` if the collection was not cached. Use
+    /// [`remove_collection_at`](Self::remove_collection_at) for a sub-collection, whose absolute
+    /// path a bare name cannot address.
+    pub async fn remove_collection<S>(&self, collection_name: S) -> FirestoreResult<bool>
+    where
+        S: AsRef<str>,
+    {
+        let collection_path = format!(
+            "{}/{}",
+            self.inner.db.get_documents_path(),
+            collection_name.as_ref()
+        );
+        self.remove_collection_at(&collection_path).await
+    }
+
+    /// Stops caching the collection at an absolute path. See
+    /// [`remove_collection`](Self::remove_collection).
+    pub async fn remove_collection_at(&self, collection_path: &str) -> FirestoreResult<bool> {
+        let Some(target) = self
+            .inner
+            .backend
+            .remove_collection(collection_path)
+            .await?
+        else {
+            return Ok(false);
+        };
+
+        self.inner
+            .listener
+            .lock()
+            .await
+            .remove_target(&target)
+            .await?;
+
+        info!(collection_path, "Removed a collection from the cache.");
+        Ok(true)
+    }
+
+    /// The absolute paths of the collections this cache currently holds.
+    pub fn cached_collections(&self) -> Vec<String> {
+        self.inner
+            .backend
+            .cache_configuration()
+            .collections
+            .keys()
+            .cloned()
+            .collect()
     }
 
     /// Returns a thread-safe reference-counted pointer to the cache backend.
@@ -473,6 +655,154 @@ pub trait FirestoreCacheBackend: FirestoreCacheDocsByPathSupport {
     /// # Returns
     /// A `FirestoreResult` indicating success or failure of processing the event.
     async fn on_listen_event(&self, event: FirestoreListenEvent) -> FirestoreResult<()>;
+
+    /// A snapshot of the collections this backend currently caches.
+    ///
+    /// [`FirestoreCache`] is generic over the backend, so this is the only way it can see the
+    /// configuration - it uses it to reject a collection that is already cached and to pick a free
+    /// listener target ID for a new one.
+    ///
+    /// The default returns an empty configuration, which disables adding and removing collections
+    /// at runtime.
+    fn cache_configuration(&self) -> Arc<FirestoreCacheConfiguration> {
+        Arc::new(FirestoreCacheConfiguration::new())
+    }
+
+    /// Starts caching a collection on a running cache.
+    ///
+    /// The backend creates the collection's storage, preloads it if the load mode asks for it, and
+    /// publishes it into its configuration only once it is fully populated. It returns the target
+    /// the cache should then start listening on.
+    ///
+    /// The default reports that the backend does not support this, so that a backend which cannot
+    /// do it fails loudly rather than quietly ignoring the request.
+    async fn add_collection(
+        &self,
+        options: &FirestoreCacheOptions,
+        db: &FirestoreDb,
+        collection_config: FirestoreCacheCollectionConfiguration,
+    ) -> FirestoreResult<FirestoreListenerTargetParams> {
+        let _ = (options, db, collection_config);
+        Err(cache_dynamic_collections_unsupported_error(
+            "add_collection",
+        ))
+    }
+
+    /// Stops caching a collection and drops its data.
+    ///
+    /// Returns the listener target that was keeping it up to date, or `None` if the collection was
+    /// not cached. See [`add_collection`](Self::add_collection) for the default behaviour.
+    async fn remove_collection(
+        &self,
+        collection_path: &str,
+    ) -> FirestoreResult<Option<FirestoreListenerTarget>> {
+        let _ = collection_path;
+        Err(cache_dynamic_collections_unsupported_error(
+            "remove_collection",
+        ))
+    }
+}
+
+/// Builds the listener target that keeps one cached collection up to date.
+///
+/// Shared by the backends and by their runtime `add_collection`, so that a collection added later
+/// is listened to exactly like one configured up front.
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+pub(crate) fn target_params_for_collection(
+    collection_config: &FirestoreCacheCollectionConfiguration,
+    resume_type: Option<FirestoreListenerTargetResumeType>,
+) -> FirestoreListenerTargetParams {
+    FirestoreListenerTargetParams::new(
+        collection_config.listener_target.clone(),
+        FirestoreTargetType::Query(
+            FirestoreQueryParams::new(collection_config.collection_name.as_str().into())
+                .opt_parent(collection_config.parent.clone()),
+        ),
+        std::collections::HashMap::new(),
+    )
+    .opt_resume_type(resume_type)
+}
+
+/// Builds the error returned when a backend does not support changing its collections at runtime.
+pub(crate) fn cache_dynamic_collections_unsupported_error(operation: &str) -> FirestoreError {
+    FirestoreError::CacheError(FirestoreCacheError::new(
+        FirestoreErrorPublicGenericDetails::new("CacheDynamicCollectionsUnsupported".into()),
+        format!(
+            "This cache backend does not support `{operation}`. Implement it on your \
+             FirestoreCacheBackend to add and remove cached collections while the cache runs."
+        ),
+    ))
+}
+
+/// What a backend should do with the collections a Firestore target change affects.
+///
+/// Firestore uses an empty set of target IDs to mean *all* targets, which this resolves for the
+/// caller.
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+pub(crate) enum FirestoreCacheTargetChangeAction {
+    /// The listener target is being replayed from scratch: drop what is cached for these
+    /// collections and stop answering `list`/`query` from them until the replay completes.
+    SuspendAndInvalidate(Vec<String>),
+    /// The listener target now reflects a consistent snapshot again: these collections may serve
+    /// `list`/`query` once more.
+    Resume(Vec<String>),
+    /// Nothing to do.
+    Ignore,
+}
+
+/// Decides what a target change means for the cache.
+///
+/// Shared by the backends so that they cannot drift apart, and kept free of any backend state so
+/// that it can be unit tested on its own.
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+pub(crate) fn cache_target_change_action(
+    config: &FirestoreCacheConfiguration,
+    target_change: &gcloud_sdk::google::firestore::v1::TargetChange,
+) -> FirestoreCacheTargetChangeAction {
+    use gcloud_sdk::google::firestore::v1::target_change::TargetChangeType;
+
+    let Ok(change_type) = TargetChangeType::try_from(target_change.target_change_type) else {
+        return FirestoreCacheTargetChangeAction::Ignore;
+    };
+
+    match change_type {
+        TargetChangeType::Reset | TargetChangeType::Remove => {
+            FirestoreCacheTargetChangeAction::SuspendAndInvalidate(affected_collection_paths(
+                config,
+                &target_change.target_ids,
+            ))
+        }
+        TargetChangeType::Current => FirestoreCacheTargetChangeAction::Resume(
+            affected_collection_paths(config, &target_change.target_ids),
+        ),
+        TargetChangeType::NoChange | TargetChangeType::Add => {
+            FirestoreCacheTargetChangeAction::Ignore
+        }
+    }
+}
+
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+fn affected_collection_paths(
+    config: &FirestoreCacheConfiguration,
+    target_ids: &[i32],
+) -> Vec<String> {
+    if target_ids.is_empty() {
+        return config
+            .all_target_scopes()
+            .into_iter()
+            .map(|scope| scope.collection_path().to_string())
+            .collect();
+    }
+
+    target_ids
+        .iter()
+        .filter_map(|target_id_num| FirestoreListenerTarget::try_from(*target_id_num).ok())
+        .filter_map(|target| {
+            config
+                .target_scope(&target)
+                .map(|scope| scope.collection_path().to_string())
+        })
+        .collect()
 }
 
 /// Defines support for retrieving and updating cached documents by their full path.
@@ -573,4 +903,147 @@ pub trait FirestoreCacheDocsByPathSupport {
         collection_path: &str,
         query: &FirestoreQueryParams,
     ) -> FirestoreResult<FirestoreCachedValue<BoxStream<'b, FirestoreResult<FirestoreDocument>>>>;
+}
+
+#[cfg(test)]
+mod target_change_tests {
+    use super::*;
+    use gcloud_sdk::google::firestore::v1::TargetChange;
+
+    const DOCS: &str = "projects/test/databases/(default)/documents";
+
+    fn config_with(collections: &[(&str, u32)]) -> FirestoreCacheConfiguration {
+        collections.iter().fold(
+            FirestoreCacheConfiguration::new(),
+            |config, (name, target)| {
+                config.add_collection_config_at(
+                    DOCS,
+                    FirestoreCacheCollectionConfiguration::new(
+                        name,
+                        FirestoreListenerTarget::new(*target),
+                        FirestoreCacheCollectionLoadMode::PreloadAllDocs,
+                    ),
+                )
+            },
+        )
+    }
+
+    fn change(
+        change_type: FirestoreListenerTargetChangeType,
+        target_ids: Vec<i32>,
+    ) -> TargetChange {
+        TargetChange {
+            target_change_type: change_type as i32,
+            target_ids,
+            ..Default::default()
+        }
+    }
+
+    fn suspended(action: FirestoreCacheTargetChangeAction) -> Vec<String> {
+        match action {
+            FirestoreCacheTargetChangeAction::SuspendAndInvalidate(paths) => sorted(paths),
+            other => panic!(
+                "expected SuspendAndInvalidate, got {}",
+                describe_action(&other)
+            ),
+        }
+    }
+
+    fn resumed(action: FirestoreCacheTargetChangeAction) -> Vec<String> {
+        match action {
+            FirestoreCacheTargetChangeAction::Resume(paths) => sorted(paths),
+            other => panic!("expected Resume, got {}", describe_action(&other)),
+        }
+    }
+
+    fn sorted(mut paths: Vec<String>) -> Vec<String> {
+        paths.sort();
+        paths
+    }
+
+    fn describe_action(action: &FirestoreCacheTargetChangeAction) -> &'static str {
+        match action {
+            FirestoreCacheTargetChangeAction::SuspendAndInvalidate(_) => "SuspendAndInvalidate",
+            FirestoreCacheTargetChangeAction::Resume(_) => "Resume",
+            FirestoreCacheTargetChangeAction::Ignore => "Ignore",
+        }
+    }
+
+    #[test]
+    fn reset_suspends_only_the_collections_of_the_named_targets() {
+        let config = config_with(&[("a", 1000), ("b", 1001)]);
+
+        let action = cache_target_change_action(
+            &config,
+            &change(FirestoreListenerTargetChangeType::Reset, vec![1000]),
+        );
+
+        assert_eq!(suspended(action), vec![format!("{DOCS}/a")]);
+    }
+
+    #[test]
+    fn remove_suspends_like_reset_does() {
+        let config = config_with(&[("a", 1000), ("b", 1001)]);
+
+        let action = cache_target_change_action(
+            &config,
+            &change(FirestoreListenerTargetChangeType::Remove, vec![1001]),
+        );
+
+        assert_eq!(suspended(action), vec![format!("{DOCS}/b")]);
+    }
+
+    #[test]
+    fn an_empty_target_id_set_means_every_target() {
+        let config = config_with(&[("a", 1000), ("b", 1001)]);
+
+        let action = cache_target_change_action(
+            &config,
+            &change(FirestoreListenerTargetChangeType::Reset, vec![]),
+        );
+
+        assert_eq!(
+            suspended(action),
+            vec![format!("{DOCS}/a"), format!("{DOCS}/b")]
+        );
+    }
+
+    #[test]
+    fn current_resumes_the_collection() {
+        let config = config_with(&[("a", 1000)]);
+
+        let action = cache_target_change_action(
+            &config,
+            &change(FirestoreListenerTargetChangeType::Current, vec![1000]),
+        );
+
+        assert_eq!(resumed(action), vec![format!("{DOCS}/a")]);
+    }
+
+    #[test]
+    fn keepalives_and_adds_do_nothing() {
+        let config = config_with(&[("a", 1000)]);
+
+        for change_type in [
+            FirestoreListenerTargetChangeType::NoChange,
+            FirestoreListenerTargetChangeType::Add,
+        ] {
+            assert!(matches!(
+                cache_target_change_action(&config, &change(change_type, vec![1000])),
+                FirestoreCacheTargetChangeAction::Ignore
+            ));
+        }
+    }
+
+    #[test]
+    fn targets_belonging_to_another_listener_are_ignored() {
+        let config = config_with(&[("a", 1000)]);
+
+        let action = cache_target_change_action(
+            &config,
+            &change(FirestoreListenerTargetChangeType::Reset, vec![42]),
+        );
+
+        assert!(suspended(action).is_empty());
+    }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -76,6 +76,13 @@
 //! construction, but they are not guaranteed to be current. Do not cache data that must be read at
 //! strong consistency - read that through Firestore directly, or inside a transaction.
 //!
+//! Firestore also reports how many documents a target matches. When that disagrees with what a
+//! preloaded collection holds - which means changes were missed, typically deletes that happened
+//! while the listener was disconnected - the cache drops the collection and has Firestore replay
+//! it. The count is only compared when it can be trusted: a collection the cache expires entries
+//! from, or fills lazily, is never checked this way, because a shortfall there is the cache doing
+//! its job rather than a divergence.
+//!
 //! When Firestore resets or removes a listener target - after a reconnect, or when a stored resume
 //! token has expired - the cache drops what it holds for that collection and Firestore replays it.
 //! While that replay is in progress the collection stops answering `list` and `query` from the
@@ -150,6 +157,7 @@
 
 use crate::errors::{FirestoreCacheError, FirestoreErrorPublicGenericDetails};
 use crate::*;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Builds the error returned when a `read_cached_only` session asks for a `list`/`query` that the
@@ -453,14 +461,16 @@ where
             listener.add_target(target_params)?;
         }
 
-        let backend = self.inner.backend.clone();
+        let handler = Arc::new(FirestoreCacheListenHandler::new(
+            self.inner.backend.clone(),
+            listener.control_handle(),
+        ));
+
         listener
             .start(move |event| {
-                let backend = backend.clone();
+                let handler = handler.clone();
                 async move {
-                    if let Err(err) = backend.on_listen_event(event).await {
-                        error!(?err, "Error occurred while updating cache.");
-                    };
+                    handler.on_listen_event(event).await;
                     Ok(())
                 }
             })
@@ -712,6 +722,33 @@ pub trait FirestoreCacheBackend: FirestoreCacheDocsByPathSupport {
         ))
     }
 
+    /// Drops everything cached for one collection and stops it answering `list`/`query` until
+    /// Firestore reports it consistent again.
+    ///
+    /// Called when the cache is found to have diverged from the server and the collection is about
+    /// to be replayed. The default invalidates the entire cache, which is correct but far coarser
+    /// than it needs to be - override it.
+    async fn begin_collection_resync(&self, collection_path: &str) -> FirestoreResult<()> {
+        let _ = collection_path;
+        self.invalidate_all().await
+    }
+
+    /// How many documents the backend holds for a collection, **when that number can be trusted
+    /// to equal the number of documents Firestore holds**.
+    ///
+    /// Used to act on Firestore's existence filter, which reports the server's count so a client
+    /// can notice that its view has diverged - typically because deletes were missed while the
+    /// listener was disconnected.
+    ///
+    /// Returning `None` (the default) disables that check for the collection, and is the right
+    /// answer whenever the backend evicts documents on its own: an undercount caused by the
+    /// backend's own eviction is not a divergence, and treating it as one would re-download the
+    /// collection over and over.
+    async fn authoritative_doc_count(&self, collection_path: &str) -> FirestoreResult<Option<u64>> {
+        let _ = collection_path;
+        Ok(None)
+    }
+
     /// Stops caching a collection and drops its data.
     ///
     /// Returns the listener target that was keeping it up to date, or `None` if the collection was
@@ -724,6 +761,184 @@ pub trait FirestoreCacheBackend: FirestoreCacheDocsByPathSupport {
         Err(cache_dynamic_collections_unsupported_error(
             "remove_collection",
         ))
+    }
+}
+
+/// The shortest interval between two resynchronisations of the same target.
+///
+/// A target whose count keeps disagreeing with Firestore would otherwise re-download its
+/// collection in a loop.
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+const FIRESTORE_CACHE_MIN_RESYNC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Applies listen events to a cache backend, and acts on the ones that say the cache has diverged.
+///
+/// This sits between the listener and the backend so that the divergence policy lives in one place
+/// rather than in each backend, and so that it can reach the listener - which a backend cannot.
+struct FirestoreCacheListenHandler<B> {
+    backend: Arc<B>,
+    listener: FirestoreListenerControlHandle,
+    state: tokio::sync::Mutex<FirestoreCacheListenState>,
+}
+
+#[derive(Default)]
+struct FirestoreCacheListenState {
+    /// Existence filters awaiting the end of their snapshot, keyed by target.
+    pending_filters: HashMap<FirestoreListenerTarget, i32>,
+    /// When each target was last resynchronised, for the rate limit.
+    last_resync: HashMap<FirestoreListenerTarget, std::time::Instant>,
+}
+
+impl<B> FirestoreCacheListenHandler<B>
+where
+    B: FirestoreCacheBackend + Send + Sync + 'static,
+{
+    fn new(backend: Arc<B>, listener: FirestoreListenerControlHandle) -> Self {
+        Self {
+            backend,
+            listener,
+            state: tokio::sync::Mutex::new(FirestoreCacheListenState::default()),
+        }
+    }
+
+    async fn on_listen_event(&self, event: FirestoreListenEvent) {
+        match &event {
+            // Firestore sends the filter and the changes of the same snapshot as a group.
+            // Comparing counts the moment it arrives would compare a half-applied snapshot, and a
+            // false mismatch costs a full re-download - so hold it until the snapshot closes.
+            FirestoreListenEvent::Filter(filter) => {
+                if let Ok(target) = FirestoreListenerTarget::try_from(filter.target_id) {
+                    if filter.unchanged_names.is_some() {
+                        debug!(
+                            ?target,
+                            "Firestore sent a bloom filter with its existence filter; this cache                              resynchronises on a count mismatch instead of using it.",
+                        );
+                    }
+                    self.state
+                        .lock()
+                        .await
+                        .pending_filters
+                        .insert(target, filter.count);
+                }
+                return;
+            }
+            FirestoreListenEvent::TargetChange(target_change) => {
+                // NO_CHANGE and CURRENT with a read time are the snapshot boundaries.
+                let settles_snapshot = matches!(
+                    FirestoreListenerTargetChangeType::try_from(target_change.target_change_type),
+                    Ok(FirestoreListenerTargetChangeType::NoChange)
+                        | Ok(FirestoreListenerTargetChangeType::Current)
+                );
+                if settles_snapshot && target_change.read_time.is_some() {
+                    self.settle_pending_filters(&target_change.target_ids).await;
+                }
+            }
+            _ => {}
+        }
+
+        if let Err(err) = self.backend.on_listen_event(event).await {
+            error!(?err, "Error occurred while updating cache.");
+        }
+    }
+
+    /// Compares the filters that were waiting on this snapshot, and resynchronises what diverged.
+    async fn settle_pending_filters(&self, target_ids: &[i32]) {
+        let settled: Vec<(FirestoreListenerTarget, i32)> = {
+            let mut state = self.state.lock().await;
+            if state.pending_filters.is_empty() {
+                return;
+            }
+            if target_ids.is_empty() {
+                state.pending_filters.drain().collect()
+            } else {
+                target_ids
+                    .iter()
+                    .filter_map(|id| FirestoreListenerTarget::try_from(*id).ok())
+                    .filter_map(|target| {
+                        state
+                            .pending_filters
+                            .remove(&target)
+                            .map(|count| (target, count))
+                    })
+                    .collect()
+            }
+        };
+
+        let config = self.backend.cache_configuration();
+        for (target, remote_count) in settled {
+            let Some(collection_path) = config
+                .collections
+                .iter()
+                .find(|(_, c)| c.listener_target == target)
+                .map(|(path, _)| path.clone())
+            else {
+                continue;
+            };
+
+            let local_count = match self.backend.authoritative_doc_count(&collection_path).await {
+                Ok(Some(count)) => count,
+                Ok(None) => {
+                    debug!(
+                        collection_path,
+                        "Cannot compare this collection's document count with Firestore's, so                          the existence filter is ignored.",
+                    );
+                    continue;
+                }
+                Err(err) => {
+                    warn!(?err, collection_path, "Could not count cached documents.");
+                    continue;
+                }
+            };
+
+            if i64::from(remote_count) == local_count as i64 {
+                trace!(
+                    collection_path,
+                    local_count,
+                    "The cache agrees with Firestore."
+                );
+                continue;
+            }
+
+            self.resync(target, &collection_path, local_count, remote_count)
+                .await;
+        }
+    }
+
+    async fn resync(
+        &self,
+        target: FirestoreListenerTarget,
+        collection_path: &str,
+        local_count: u64,
+        remote_count: i32,
+    ) {
+        {
+            let mut state = self.state.lock().await;
+            if let Some(last) = state.last_resync.get(&target) {
+                if last.elapsed() < FIRESTORE_CACHE_MIN_RESYNC_INTERVAL {
+                    warn!(
+                        collection_path,
+                        local_count,
+                        remote_count,
+                        "The cache still disagrees with Firestore, but it was resynchronised                          recently. Skipping this one.",
+                    );
+                    return;
+                }
+            }
+            state
+                .last_resync
+                .insert(target.clone(), std::time::Instant::now());
+        }
+
+        warn!(
+            collection_path,
+            local_count,
+            remote_count,
+            "The cache holds a different number of documents than Firestore reports, so it has              missed changes. Resynchronising the collection.",
+        );
+
+        // The listener discards the target's resume state and reopens the stream; Firestore then
+        // replays the collection, and the reset that arrives with it empties the stale copy.
+        self.listener.resync_target(target);
     }
 }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -84,6 +84,30 @@
 //! `read_cached_only` returns a [`FirestoreError::CacheError`](crate::errors::FirestoreError::CacheError).
 //! Reads by ID are unaffected beyond behaving like a cache miss.
 //!
+//! # Caching named documents instead of a whole collection
+//!
+//! `.collection(name)` subscribes the listener to the **entire** collection, even though it does
+//! not preload it - "lazy" only means the initial download is skipped. When you know which
+//! documents you care about, say so:
+//!
+//! ```rust,no_run
+//! # use firestore::*;
+//! # async fn example(db: &FirestoreDb) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//! let cache = FirestoreCache::memory(db)
+//!     .collection_with("configs", |c| c.documents(["site", "billing"]).preload_all())
+//!     .build()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The listener then watches exactly those documents, so unrelated changes in the collection are
+//! never streamed to your process or written into the cache, and preloading reads just those IDs.
+//! This is the shape to reach for with configuration, feature flags and reference data.
+//!
+//! Such a collection is never listable, whatever its load mode: it holds a chosen subset, so
+//! `list` and `query` would return a partial answer that looks complete.
+//!
 //! # Changing the cached collections at runtime
 //!
 //! The set of cached collections does not have to be fixed when the cache is built:
@@ -712,12 +736,25 @@ pub(crate) fn target_params_for_collection(
     collection_config: &FirestoreCacheCollectionConfiguration,
     resume_type: Option<FirestoreListenerTargetResumeType>,
 ) -> FirestoreListenerTargetParams {
-    FirestoreListenerTargetParams::new(
-        collection_config.listener_target.clone(),
-        FirestoreTargetType::Query(
+    let target_type = match collection_config.watched_document_ids() {
+        // Watching named documents keeps unrelated changes in the collection off the wire
+        // entirely, instead of streaming them here only to be filtered out.
+        Some(document_ids) => FirestoreTargetType::Documents(
+            FirestoreCollectionDocuments::new(
+                collection_config.collection_name.clone(),
+                document_ids.to_vec(),
+            )
+            .opt_parent(collection_config.parent.clone()),
+        ),
+        None => FirestoreTargetType::Query(
             FirestoreQueryParams::new(collection_config.collection_name.as_str().into())
                 .opt_parent(collection_config.parent.clone()),
         ),
+    };
+
+    FirestoreListenerTargetParams::new(
+        collection_config.listener_target.clone(),
+        target_type,
         std::collections::HashMap::new(),
     )
     .opt_resume_type(resume_type)
@@ -740,14 +777,40 @@ pub(crate) fn cache_dynamic_collections_unsupported_error(operation: &str) -> Fi
 /// caller.
 #[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
 pub(crate) enum FirestoreCacheTargetChangeAction {
-    /// The listener target is being replayed from scratch: drop what is cached for these
-    /// collections and stop answering `list`/`query` from them until the replay completes.
-    SuspendAndInvalidate(Vec<String>),
-    /// The listener target now reflects a consistent snapshot again: these collections may serve
+    /// The listener targets are being replayed from scratch: drop what is cached for them and stop
+    /// answering `list`/`query` from their collections until the replay completes.
+    SuspendAndInvalidate(Vec<FirestoreCacheInvalidation>),
+    /// The listener targets now reflect a consistent snapshot again: their collections may serve
     /// `list`/`query` once more.
     Resume(Vec<String>),
     /// Nothing to do.
     Ignore,
+}
+
+/// What one target change asks the backend to drop.
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) enum FirestoreCacheInvalidation {
+    /// Drop every document cached for this collection.
+    Collection(String),
+    /// Drop only these documents of the collection - the target watches nothing else, so wiping
+    /// the whole collection would throw away documents it never covered.
+    Documents {
+        collection_path: String,
+        document_ids: Vec<String>,
+    },
+}
+
+#[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
+impl FirestoreCacheInvalidation {
+    pub(crate) fn collection_path(&self) -> &str {
+        match self {
+            Self::Collection(collection_path) => collection_path,
+            Self::Documents {
+                collection_path, ..
+            } => collection_path,
+        }
+    }
 }
 
 /// Decides what a target change means for the cache.
@@ -767,13 +830,29 @@ pub(crate) fn cache_target_change_action(
 
     match change_type {
         TargetChangeType::Reset | TargetChangeType::Remove => {
-            FirestoreCacheTargetChangeAction::SuspendAndInvalidate(affected_collection_paths(
-                config,
-                &target_change.target_ids,
-            ))
+            FirestoreCacheTargetChangeAction::SuspendAndInvalidate(
+                affected_scopes(config, &target_change.target_ids)
+                    .into_iter()
+                    .map(|scope| match scope {
+                        FirestoreCacheTargetScope::Collection(collection_path) => {
+                            FirestoreCacheInvalidation::Collection(collection_path.to_string())
+                        }
+                        FirestoreCacheTargetScope::Documents {
+                            collection_path,
+                            document_ids,
+                        } => FirestoreCacheInvalidation::Documents {
+                            collection_path: collection_path.to_string(),
+                            document_ids: document_ids.to_vec(),
+                        },
+                    })
+                    .collect(),
+            )
         }
         TargetChangeType::Current => FirestoreCacheTargetChangeAction::Resume(
-            affected_collection_paths(config, &target_change.target_ids),
+            affected_scopes(config, &target_change.target_ids)
+                .into_iter()
+                .map(|scope| scope.collection_path().to_string())
+                .collect(),
         ),
         TargetChangeType::NoChange | TargetChangeType::Add => {
             FirestoreCacheTargetChangeAction::Ignore
@@ -782,26 +861,18 @@ pub(crate) fn cache_target_change_action(
 }
 
 #[cfg(any(feature = "caching-memory", feature = "caching-persistent"))]
-fn affected_collection_paths(
-    config: &FirestoreCacheConfiguration,
+fn affected_scopes<'a>(
+    config: &'a FirestoreCacheConfiguration,
     target_ids: &[i32],
-) -> Vec<String> {
+) -> Vec<FirestoreCacheTargetScope<'a>> {
     if target_ids.is_empty() {
-        return config
-            .all_target_scopes()
-            .into_iter()
-            .map(|scope| scope.collection_path().to_string())
-            .collect();
+        return config.all_target_scopes();
     }
 
     target_ids
         .iter()
         .filter_map(|target_id_num| FirestoreListenerTarget::try_from(*target_id_num).ok())
-        .filter_map(|target| {
-            config
-                .target_scope(&target)
-                .map(|scope| scope.collection_path().to_string())
-        })
+        .filter_map(|target| config.target_scope(&target))
         .collect()
 }
 
@@ -941,7 +1012,12 @@ mod target_change_tests {
 
     fn suspended(action: FirestoreCacheTargetChangeAction) -> Vec<String> {
         match action {
-            FirestoreCacheTargetChangeAction::SuspendAndInvalidate(paths) => sorted(paths),
+            FirestoreCacheTargetChangeAction::SuspendAndInvalidate(invalidations) => sorted(
+                invalidations
+                    .into_iter()
+                    .map(|invalidation| invalidation.collection_path().to_string())
+                    .collect(),
+            ),
             other => panic!(
                 "expected SuspendAndInvalidate, got {}",
                 describe_action(&other)

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -237,16 +237,18 @@ where
     pub listener: tokio::sync::Mutex<FirestoreListener<FirestoreDb, LS>>,
     /// A clone of the Firestore database client.
     pub db: FirestoreDb,
-    /// Serialises adding and removing collections.
+    /// Serialises adding and removing collections, and holds the next listener target ID to give
+    /// to one added at runtime.
     ///
-    /// Without it two concurrent `add_collection` calls could both pass the "already cached" check
-    /// before either published its entry, leaving one of the two listener targets orphaned.
-    pub collection_mutations: tokio::sync::Mutex<()>,
-    /// The next listener target ID to hand out to a collection added at runtime.
+    /// The two belong together: the ID counter is exactly the state that serialising protects.
+    /// Without it, two concurrent `add_collection` calls could both pass the "already cached"
+    /// check before either published its entry, leaving one of the two listener targets orphaned.
     ///
-    /// Monotonic on purpose: an ID freed by `remove_collection` is never reissued in this process,
-    /// so a resume token that outlived its target cannot be applied to a different query.
-    pub next_listener_target: std::sync::Mutex<u32>,
+    /// Kept separate from the listener's own lock so that a slow preload does not hold up
+    /// `shutdown`. The counter only ever increases: an ID freed by `remove_collection` is not
+    /// reissued in this process, so a resume token that outlived its target cannot end up applied
+    /// to a different query.
+    pub collection_mutations: tokio::sync::Mutex<u32>,
 }
 
 /// A ready-to-use in-memory cache.
@@ -434,8 +436,7 @@ where
                 backend: Arc::new(backend),
                 listener: tokio::sync::Mutex::new(listener),
                 db: db.clone(),
-                collection_mutations: tokio::sync::Mutex::new(()),
-                next_listener_target: std::sync::Mutex::new(next_listener_target),
+                collection_mutations: tokio::sync::Mutex::new(next_listener_target),
             },
         })
     }
@@ -532,7 +533,7 @@ where
         &self,
         collection: FirestoreCacheCollection,
     ) -> FirestoreResult<()> {
-        let _mutation = self.inner.collection_mutations.lock().await;
+        let mut next_listener_target = self.inner.collection_mutations.lock().await;
 
         let documents_path = self.inner.db.get_documents_path();
         let config = self.inner.backend.cache_configuration();
@@ -546,13 +547,8 @@ where
             None => {
                 // Never reuse an ID freed by `remove_collection`: a resume token belongs to one
                 // target's query, so handing the ID to a different one would resume it wrongly.
-                let mut next = self
-                    .inner
-                    .next_listener_target
-                    .lock()
-                    .expect("cache listener target counter poisoned");
-                let allocated = config.allocate_listener_target(*next)?;
-                *next = allocated.value().saturating_add(1);
+                let allocated = config.allocate_listener_target(*next_listener_target)?;
+                *next_listener_target = allocated.value().saturating_add(1);
                 allocated
             }
         };

--- a/src/db/listen_changes.rs
+++ b/src/db/listen_changes.rs
@@ -238,6 +238,25 @@ pub struct FirestoreListenerParams {
     pub retry_delay: Option<std::time::Duration>,
 }
 
+/// The set of targets a listener listens on, shared between the handle and its running loop.
+///
+/// A `std::sync::RwLock` rather than tokio's: it keeps [`FirestoreListener::add_target`]
+/// synchronous, and the compiler stops a guard being held across an await. Every use site clones
+/// out what it needs and drops the guard before awaiting.
+pub(crate) type FirestoreListenerTargetsState =
+    Arc<std::sync::RwLock<HashMap<FirestoreListenerTarget, FirestoreListenerTargetParams>>>;
+
+/// A message to a running listener loop.
+///
+/// [`TargetsChanged`](Self::TargetsChanged) deliberately carries no payload: the shared target map
+/// is the single source of truth, so a change applies on the next reconnect even if the message is
+/// lost or arrives late.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum FirestoreListenerControl {
+    Shutdown,
+    TargetsChanged,
+}
+
 pub struct FirestoreListener<D, S>
 where
     D: FirestoreListenSupport,
@@ -246,10 +265,13 @@ where
     db: D,
     storage: S,
     listener_params: FirestoreListenerParams,
-    targets: Vec<FirestoreListenerTargetParams>,
+    targets: FirestoreListenerTargetsState,
     shutdown_flag: Arc<AtomicBool>,
     shutdown_handle: Option<JoinHandle<()>>,
-    shutdown_writer: Option<Arc<UnboundedSender<i8>>>,
+    /// Created up front rather than in `start`, so that targets can be added and removed before,
+    /// during and after the listener runs.
+    control_writer: Arc<UnboundedSender<FirestoreListenerControl>>,
+    control_reader: Option<UnboundedReceiver<FirestoreListenerControl>>,
 }
 
 impl<D, S> FirestoreListener<D, S>
@@ -262,24 +284,113 @@ where
         storage: S,
         listener_params: FirestoreListenerParams,
     ) -> FirestoreResult<FirestoreListener<D, S>> {
+        let (control_writer, control_reader) = tokio::sync::mpsc::unbounded_channel();
+
         Ok(FirestoreListener {
             db,
             storage,
             listener_params,
-            targets: vec![],
+            targets: Arc::new(std::sync::RwLock::new(HashMap::new())),
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             shutdown_handle: None,
-            shutdown_writer: None,
+            control_writer: Arc::new(control_writer),
+            control_reader: Some(control_reader),
         })
     }
 
-    pub fn add_target(
-        &mut self,
-        target_params: FirestoreListenerTargetParams,
-    ) -> FirestoreResult<()> {
+    /// Adds a target to listen on.
+    ///
+    /// This works before and after [`start`](Self::start): a target added to a running listener
+    /// joins it once the listen stream has been reopened with the new set, which happens straight
+    /// away.
+    ///
+    /// Returns an error if the listener has been shut down, or if a target with the same ID is
+    /// already registered - reusing an ID for a different query would resume it from a token that
+    /// does not belong to it.
+    pub fn add_target(&self, target_params: FirestoreListenerTargetParams) -> FirestoreResult<()> {
         target_params.validate()?;
-        self.targets.push(target_params);
+
+        if self.shutdown_flag.load(Ordering::Relaxed) {
+            return Err(FirestoreError::InvalidParametersError(
+                FirestoreInvalidParametersError::new(FirestoreInvalidParametersPublicDetails::new(
+                    "target".to_string(),
+                    "Cannot add a target to a listener that has been shut down".to_string(),
+                )),
+            ));
+        }
+
+        {
+            let mut targets = self
+                .targets
+                .write()
+                .expect("listener targets lock poisoned");
+            if targets.contains_key(&target_params.target) {
+                return Err(FirestoreError::InvalidParametersError(
+                    FirestoreInvalidParametersError::new(
+                        FirestoreInvalidParametersPublicDetails::new(
+                            "target".to_string(),
+                            format!(
+                                "Listener target {} is already registered on this listener",
+                                target_params.target.value()
+                            ),
+                        ),
+                    ),
+                ));
+            }
+            targets.insert(target_params.target.clone(), target_params);
+        }
+
+        // A send error only means the loop is gone, which the shutdown check above already covers.
+        self.control_writer
+            .send(FirestoreListenerControl::TargetsChanged)
+            .ok();
         Ok(())
+    }
+
+    /// Stops listening on a target and forgets its stored resume state.
+    ///
+    /// Returns `false` if the target was not registered. Unlike [`add_target`](Self::add_target)
+    /// this is asynchronous, because the resume state has to be forgotten before the target ID can
+    /// safely be handed out again.
+    pub async fn remove_target(&self, target: &FirestoreListenerTarget) -> FirestoreResult<bool> {
+        let removed = {
+            let mut targets = self
+                .targets
+                .write()
+                .expect("listener targets lock poisoned");
+            targets.remove(target).is_some()
+        };
+
+        if !removed {
+            return Ok(false);
+        }
+
+        if let Err(err) = self.storage.forget_resume_state(target).await {
+            warn!(%err, ?target, "Could not forget the resume state of a removed listener target.");
+        }
+
+        self.control_writer
+            .send(FirestoreListenerControl::TargetsChanged)
+            .ok();
+        Ok(true)
+    }
+
+    /// The targets this listener currently listens on.
+    pub fn targets(&self) -> Vec<FirestoreListenerTarget> {
+        self.targets
+            .read()
+            .expect("listener targets lock poisoned")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    /// Whether this listener listens on the given target.
+    pub fn has_target(&self, target: &FirestoreListenerTarget) -> bool {
+        self.targets
+            .read()
+            .expect("listener targets lock poisoned")
+            .contains_key(target)
     }
 
     pub async fn start<FN, F>(&mut self, cb: FN) -> FirestoreResult<()>
@@ -287,56 +398,71 @@ where
         FN: Fn(FirestoreListenEvent) -> F + Send + Sync + 'static,
         F: Future<Output = AnyBoxedErrResult<()>> + Send + 'static,
     {
+        let initial_targets: Vec<FirestoreListenerTargetParams> = self
+            .targets
+            .read()
+            .expect("listener targets lock poisoned")
+            .values()
+            .cloned()
+            .collect();
+
         info!(
-            num_targets = self.targets.len(),
+            num_targets = initial_targets.len(),
             "Starting a Firestore listener for targets...",
         );
 
-        let mut initial_states: HashMap<FirestoreListenerTarget, FirestoreListenerTargetParams> =
-            HashMap::new();
-        for target_params in &self.targets {
-            match &target_params.resume_type {
-                Some(resume_type) => {
-                    initial_states.insert(
-                        target_params.target.clone(),
-                        target_params.clone().with_resume_type(resume_type.clone()),
-                    );
-                }
-                None => {
-                    let resume_type = self
-                        .storage
-                        .read_resume_state(&target_params.target)
-                        .map_err(|err| {
-                            FirestoreError::SystemError(FirestoreSystemError::new(
-                                FirestoreErrorPublicGenericDetails::new("SystemError".into()),
-                                format!("Listener init error: {err}"),
-                            ))
-                        })
-                        .await?;
-                    initial_states.insert(
-                        target_params.target.clone(),
-                        target_params.clone().opt_resume_type(resume_type),
-                    );
+        // Resolved eagerly rather than left to the loop, so that a broken resume-state storage is
+        // reported to the caller of `start` instead of only appearing in the logs.
+        for target_params in initial_targets {
+            if target_params.resume_type.is_some() {
+                continue;
+            }
+            let resume_type = self
+                .storage
+                .read_resume_state(&target_params.target)
+                .map_err(|err| {
+                    FirestoreError::SystemError(FirestoreSystemError::new(
+                        FirestoreErrorPublicGenericDetails::new("SystemError".into()),
+                        format!("Listener init error: {err}"),
+                    ))
+                })
+                .await?;
+
+            if let Some(resume_type) = resume_type {
+                let mut targets = self
+                    .targets
+                    .write()
+                    .expect("listener targets lock poisoned");
+                if let Some(target) = targets.get_mut(&target_params.target) {
+                    target.resume_type = Some(resume_type);
                 }
             }
         }
 
-        if initial_states.is_empty() {
-            warn!("No initial states for listener targets. Exiting...");
-            return Ok(());
+        let Some(mut control_reader) = self.control_reader.take() else {
+            return Err(FirestoreError::InvalidParametersError(
+                FirestoreInvalidParametersError::new(FirestoreInvalidParametersPublicDetails::new(
+                    "listener".to_string(),
+                    "This Firestore listener has already been started".to_string(),
+                )),
+            ));
+        };
+
+        // Targets added before `start` already appear in the shared state the loop is about to
+        // connect with, so their queued notifications would only cause a pointless reconnect.
+        while let Ok(queued) = control_reader.try_recv() {
+            if queued == FirestoreListenerControl::Shutdown {
+                self.shutdown_flag.store(true, Ordering::Relaxed);
+            }
         }
 
-        let (tx, rx): (UnboundedSender<i8>, UnboundedReceiver<i8>) =
-            tokio::sync::mpsc::unbounded_channel();
-
-        self.shutdown_writer = Some(Arc::new(tx));
         self.shutdown_handle = Some(tokio::spawn(Self::listener_loop(
             self.db.clone(),
             self.storage.clone(),
             self.shutdown_flag.clone(),
-            initial_states,
+            self.targets.clone(),
             self.listener_params.clone(),
-            rx,
+            control_reader,
             cb,
         )));
         Ok(())
@@ -345,9 +471,9 @@ where
     pub async fn shutdown(&mut self) -> FirestoreResult<()> {
         debug!("Shutting down Firestore listener...");
         self.shutdown_flag.store(true, Ordering::Relaxed);
-        if let Some(shutdown_writer) = self.shutdown_writer.take() {
-            shutdown_writer.send(1).ok();
-        }
+        self.control_writer
+            .send(FirestoreListenerControl::Shutdown)
+            .ok();
         if let Some(signaller) = self.shutdown_handle.take() {
             if let Err(err) = signaller.await {
                 warn!(%err, "Firestore listener exit error!");
@@ -361,9 +487,9 @@ where
         db: D,
         storage: S,
         shutdown_flag: Arc<AtomicBool>,
-        mut targets_state: HashMap<FirestoreListenerTarget, FirestoreListenerTargetParams>,
+        targets_state: FirestoreListenerTargetsState,
         listener_params: FirestoreListenerParams,
-        mut shutdown_receiver: UnboundedReceiver<i8>,
+        mut control_receiver: UnboundedReceiver<FirestoreListenerControl>,
         cb: FN,
     ) where
         D: FirestoreListenSupport + Clone + Send + Sync,
@@ -374,31 +500,70 @@ where
             .retry_delay
             .unwrap_or_else(|| std::time::Duration::from_secs(5));
 
+        // Set once we have retried with every resume token discarded, so that a request Firestore
+        // still rejects as invalid is treated as permanent instead of looping forever.
+        let mut retried_without_resume_tokens = false;
+
         while !shutdown_flag.load(Ordering::Relaxed) {
+            let snapshot = Self::resolve_targets(&storage, &targets_state).await;
+
+            if snapshot.is_empty() {
+                // Nothing to listen on yet. Idle on the control channel rather than opening an
+                // empty stream, so that a listener can be started before its targets exist.
+                debug!("Firestore listener has no targets. Waiting for one to be added...");
+                match control_receiver.recv().await {
+                    None | Some(FirestoreListenerControl::Shutdown) => {
+                        shutdown_flag.store(true, Ordering::Relaxed);
+                    }
+                    Some(FirestoreListenerControl::TargetsChanged) => {}
+                }
+                continue;
+            }
+
             debug!(
-                num_targets = targets_state.len(),
+                num_targets = snapshot.len(),
                 "Start listening on targets..."
             );
 
-            match db
-                .listen_doc_changes(targets_state.values().cloned().collect())
-                .await
-            {
+            match db.listen_doc_changes(snapshot).await {
                 Err(err) => {
-                    if Self::check_listener_if_permanent_error(err, effective_delay).await {
-                        shutdown_flag.store(true, Ordering::Relaxed);
-                    }
+                    Self::handle_listener_error(
+                        err,
+                        effective_delay,
+                        &storage,
+                        &targets_state,
+                        &shutdown_flag,
+                        &mut retried_without_resume_tokens,
+                    )
+                    .await;
                 }
                 Ok(mut listen_stream) => loop {
                     tokio::select! {
-                        shutdown_trigger = shutdown_receiver.recv() => {
-                            if shutdown_trigger.is_none() {
-                                debug!("Listener dropped. Exiting...");
-                                shutdown_flag.store(true, Ordering::Relaxed);
+                        control = control_receiver.recv() => {
+                            match control {
+                                None => {
+                                    debug!("Listener dropped. Exiting...");
+                                    shutdown_flag.store(true, Ordering::Relaxed);
+                                    break;
+                                }
+                                Some(FirestoreListenerControl::Shutdown) => {
+                                    debug!("Exiting from listener on targets...");
+                                    control_receiver.close();
+                                    break;
+                                }
+                                Some(FirestoreListenerControl::TargetsChanged) => {
+                                    // Collapse a burst of changes into a single reconnect.
+                                    while let Ok(queued) = control_receiver.try_recv() {
+                                        if queued == FirestoreListenerControl::Shutdown {
+                                            shutdown_flag.store(true, Ordering::Relaxed);
+                                            control_receiver.close();
+                                            break;
+                                        }
+                                    }
+                                    debug!("Listener targets changed. Reopening the stream with the new set...");
+                                    break;
+                                }
                             }
-                            debug!(num_targets = targets_state.len(), "Exiting from listener on targets...");
-                            shutdown_receiver.close();
-                            break;
                         }
                         tried = listen_stream.try_next() => {
                             if shutdown_flag.load(Ordering::Relaxed) {
@@ -409,32 +574,61 @@ where
                                     Ok(Some(event)) => {
                                         trace!(?event, "Received a listen response event to handle.");
 
-                                        match event.response_type {
-                                            Some(listen_response::ResponseType::TargetChange(ref target_change))
-                                                if !target_change.resume_token.is_empty() =>
-                                            {
-                                                for target_id_num in &target_change.target_ids {
-                                                    match FirestoreListenerTarget::try_from(*target_id_num) {
-                                                        Ok(target_id) => {
-                                                            if let Some(target) = targets_state.get_mut(&target_id) {
-                                                                let new_token: FirestoreListenerToken = target_change.resume_token.clone().into();
+                                        // The connection works, so a later rejection deserves its
+                                        // own token-discarding retry.
+                                        retried_without_resume_tokens = false;
 
-                                                                if let Err(err) = storage.update_resume_token(&target.target, new_token.clone()).await {
-                                                                    error!(%err, "Listener token storage error occurred.");
-                                                                    break;
-                                                                }
-                                                                else {
-                                                                    target.resume_type = Some(FirestoreListenerTargetResumeType::Token(new_token))
-                                                                }
-                                                            }
-                                                        },
-                                                        Err(err) => {
-                                                            error!(%err, target_id_num, "Listener system error - unexpected target ID.");
-                                                            break;
-                                                        }
-                                                    }
+                                        match event.response_type {
+                                            Some(listen_response::ResponseType::TargetChange(target_change)) => {
+                                                if !target_change.resume_token.is_empty()
+                                                    && !Self::store_resume_token(&storage, &targets_state, &target_change).await
+                                                {
+                                                    break;
                                                 }
 
+                                                let change_type = target_change::TargetChangeType::try_from(
+                                                    target_change.target_change_type,
+                                                ).ok();
+                                                let affected = Self::affected_targets(&targets_state, &target_change.target_ids);
+                                                let cause = target_change.cause.clone();
+
+                                                // Anything listening on this - the cache above all -
+                                                // has to see the change, and drop what it holds for a
+                                                // reset target, before the stream is reopened.
+                                                if let Err(err) = cb(listen_response::ResponseType::TargetChange(target_change)).await {
+                                                    error!(%err, "Listener callback function error occurred.");
+                                                    break;
+                                                }
+
+                                                match (change_type, affected) {
+                                                    (Some(target_change::TargetChangeType::Remove), Ok(affected)) => {
+                                                        error!(
+                                                            ?affected,
+                                                            ?cause,
+                                                            ?effective_delay,
+                                                            "Firestore removed listener targets. Discarding their resume state and reopening the stream after the retry delay to add them again.",
+                                                        );
+                                                        Self::forget_resume_states(&storage, &targets_state, &affected).await;
+                                                        // Without this a target Firestore keeps
+                                                        // rejecting would reconnect in a tight loop.
+                                                        tokio::time::sleep(effective_delay).await;
+                                                        break;
+                                                    }
+                                                    (Some(target_change::TargetChangeType::Reset), Ok(affected)) => {
+                                                        // Firestore resends the initial state on this
+                                                        // same stream and only then issues a new
+                                                        // token. Dropping the old one now means a
+                                                        // disconnect in between resumes from scratch
+                                                        // rather than from a point the reset has
+                                                        // already invalidated.
+                                                        warn!(
+                                                            ?affected,
+                                                            "Firestore reset listener targets. Their initial state will be resent.",
+                                                        );
+                                                        Self::forget_resume_states(&storage, &targets_state, &affected).await;
+                                                    }
+                                                    _ => {}
+                                                }
                                             }
                                             Some(response_type) => {
                                                 if let Err(err) = cb(response_type).await {
@@ -447,9 +641,14 @@ where
                                     }
                                     Ok(None) => break,
                                     Err(err) => {
-                                        if Self::check_listener_if_permanent_error(err, effective_delay).await {
-                                            shutdown_flag.store(true, Ordering::Relaxed);
-                                        }
+                                        Self::handle_listener_error(
+                                            err,
+                                            effective_delay,
+                                            &storage,
+                                            &targets_state,
+                                            &shutdown_flag,
+                                            &mut retried_without_resume_tokens,
+                                        ).await;
                                         break;
                                     }
                                 }
@@ -461,34 +660,213 @@ where
         }
     }
 
-    async fn check_listener_if_permanent_error(
-        err: FirestoreError,
-        delay: std::time::Duration,
+    /// Resolves the targets a target change applies to.
+    ///
+    /// Firestore uses an empty set of target IDs to mean *all* targets, which is how global resume
+    /// tokens and stream-wide resets arrive. Target IDs this listener does not know about are
+    /// ignored; an ID that is not a valid target at all is a protocol error and returns `Err`.
+    fn affected_targets(
+        targets_state: &FirestoreListenerTargetsState,
+        target_ids: &[i32],
+    ) -> Result<Vec<FirestoreListenerTarget>, ()> {
+        let targets = targets_state
+            .read()
+            .expect("listener targets lock poisoned");
+
+        if target_ids.is_empty() {
+            return Ok(targets.keys().cloned().collect());
+        }
+
+        let mut affected = Vec::with_capacity(target_ids.len());
+        for target_id_num in target_ids {
+            match FirestoreListenerTarget::try_from(*target_id_num) {
+                Ok(target_id) => {
+                    if targets.contains_key(&target_id) {
+                        affected.push(target_id);
+                    }
+                }
+                Err(err) => {
+                    error!(%err, target_id_num, "Listener system error - unexpected target ID.");
+                    return Err(());
+                }
+            }
+        }
+        Ok(affected)
+    }
+
+    /// Snapshots the targets to listen on, filling in any resume state that is not resolved yet.
+    ///
+    /// Reading the storage here rather than only in `start` is what lets a target added at runtime
+    /// pick up a token stored by an earlier run, and what makes a target whose token was discarded
+    /// come back cleanly.
+    async fn resolve_targets(
+        storage: &S,
+        targets_state: &FirestoreListenerTargetsState,
+    ) -> Vec<FirestoreListenerTargetParams> {
+        let unresolved: Vec<FirestoreListenerTarget> = {
+            let targets = targets_state
+                .read()
+                .expect("listener targets lock poisoned");
+            targets
+                .values()
+                .filter(|params| params.resume_type.is_none())
+                .map(|params| params.target.clone())
+                .collect()
+        };
+
+        for target in unresolved {
+            match storage.read_resume_state(&target).await {
+                Ok(Some(resume_type)) => {
+                    let mut targets = targets_state
+                        .write()
+                        .expect("listener targets lock poisoned");
+                    if let Some(params) = targets.get_mut(&target) {
+                        params.resume_type = Some(resume_type);
+                    }
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    warn!(%err, ?target, "Could not read the resume state of a listener target. Listening on it from scratch.");
+                }
+            }
+        }
+
+        targets_state
+            .read()
+            .expect("listener targets lock poisoned")
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    /// Persists a resume token for every target the change applies to.
+    ///
+    /// Returns `false` when the token could not be stored, in which case the caller reopens the
+    /// stream rather than carrying on from a position the storage does not know about.
+    async fn store_resume_token(
+        storage: &S,
+        targets_state: &FirestoreListenerTargetsState,
+        target_change: &TargetChange,
     ) -> bool {
-        match err {
-            FirestoreError::DatabaseError(ref db_err)
-                if db_err.details.contains("unexpected end of file")
-                    || db_err.details.contains("stream error received") =>
+        let Ok(affected) = Self::affected_targets(targets_state, &target_change.target_ids) else {
+            return false;
+        };
+
+        let new_token: FirestoreListenerToken = target_change.resume_token.clone().into();
+
+        for target_id in affected {
+            if let Err(err) = storage
+                .update_resume_token(&target_id, new_token.clone())
+                .await
             {
-                debug!(%err, ?delay, "Listen EOF.. Restarting after the specified delay...");
-                tokio::time::sleep(delay).await;
-                false
+                error!(%err, "Listener token storage error occurred.");
+                return false;
             }
-            FirestoreError::DatabaseError(ref db_err)
-                if db_err.public.code.contains("InvalidArgument") =>
-            {
-                error!(%err, "Listen error. Exiting...");
-                true
+            let mut targets = targets_state
+                .write()
+                .expect("listener targets lock poisoned");
+            if let Some(target) = targets.get_mut(&target_id) {
+                target.resume_type =
+                    Some(FirestoreListenerTargetResumeType::Token(new_token.clone()));
             }
-            FirestoreError::InvalidParametersError(_) => {
-                error!(%err, "Listen error. Exiting...");
-                true
+        }
+
+        true
+    }
+
+    /// Discards the stored resume state of the given targets, so that they are listened to from
+    /// scratch the next time the stream is opened.
+    async fn forget_resume_states(
+        storage: &S,
+        targets_state: &FirestoreListenerTargetsState,
+        targets: &[FirestoreListenerTarget],
+    ) {
+        for target_id in targets {
+            if let Err(err) = storage.forget_resume_state(target_id).await {
+                warn!(%err, ?target_id, "Could not forget the resume state of a listener target.");
             }
-            _ => {
-                error!(%err, ?delay, "Listen error. Restarting after the specified delay...");
-                tokio::time::sleep(delay).await;
-                false
+            let mut state = targets_state
+                .write()
+                .expect("listener targets lock poisoned");
+            if let Some(target) = state.get_mut(target_id) {
+                target.resume_type = None;
             }
         }
     }
+
+    async fn handle_listener_error(
+        err: FirestoreError,
+        delay: std::time::Duration,
+        storage: &S,
+        targets_state: &FirestoreListenerTargetsState,
+        shutdown_flag: &Arc<AtomicBool>,
+        retried_without_resume_tokens: &mut bool,
+    ) {
+        match Self::classify_listener_error(&err) {
+            FirestoreListenerErrorAction::Retry => {
+                debug!(%err, ?delay, "Listen EOF.. Restarting after the specified delay...");
+                tokio::time::sleep(delay).await;
+            }
+            FirestoreListenerErrorAction::RetryWithoutResumeTokens
+                if !*retried_without_resume_tokens =>
+            {
+                // A stored resume token belongs to one target's query, so a stale or expired one
+                // is rejected as invalid. Dropping every token costs a replay; treating this as
+                // permanent would instead take down the listener for all the other targets too.
+                *retried_without_resume_tokens = true;
+                warn!(
+                    %err, ?delay,
+                    "Firestore rejected the listen request as invalid. Discarding all stored resume tokens and retrying once from scratch...",
+                );
+                let all_targets: Vec<FirestoreListenerTarget> = targets_state
+                    .read()
+                    .expect("listener targets lock poisoned")
+                    .keys()
+                    .cloned()
+                    .collect();
+                Self::forget_resume_states(storage, targets_state, &all_targets).await;
+                tokio::time::sleep(delay).await;
+            }
+            FirestoreListenerErrorAction::RetryWithoutResumeTokens
+            | FirestoreListenerErrorAction::Fatal => {
+                error!(%err, "Listen error. Exiting...");
+                shutdown_flag.store(true, Ordering::Relaxed);
+            }
+            FirestoreListenerErrorAction::RetryAfterDelay => {
+                error!(%err, ?delay, "Listen error. Restarting after the specified delay...");
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+
+    fn classify_listener_error(err: &FirestoreError) -> FirestoreListenerErrorAction {
+        match err {
+            FirestoreError::DatabaseError(db_err)
+                if db_err.details.contains("unexpected end of file")
+                    || db_err.details.contains("stream error received") =>
+            {
+                FirestoreListenerErrorAction::Retry
+            }
+            FirestoreError::DatabaseError(db_err)
+                if db_err.public.code.contains("InvalidArgument") =>
+            {
+                FirestoreListenerErrorAction::RetryWithoutResumeTokens
+            }
+            FirestoreError::InvalidParametersError(_) => FirestoreListenerErrorAction::Fatal,
+            _ => FirestoreListenerErrorAction::RetryAfterDelay,
+        }
+    }
+}
+
+/// How the listener should react to a failed listen request or stream.
+enum FirestoreListenerErrorAction {
+    /// Reconnect after the retry delay, keeping the stored resume state.
+    Retry,
+    /// Same, but logged as an error rather than as an expected end of stream.
+    RetryAfterDelay,
+    /// Firestore rejected the request as invalid, which a stale resume token can cause. Retry once
+    /// with every resume token discarded before giving up.
+    RetryWithoutResumeTokens,
+    /// Nothing a retry can fix.
+    Fatal,
 }

--- a/src/db/listen_changes.rs
+++ b/src/db/listen_changes.rs
@@ -251,10 +251,34 @@ pub(crate) type FirestoreListenerTargetsState =
 /// [`TargetsChanged`](Self::TargetsChanged) deliberately carries no payload: the shared target map
 /// is the single source of truth, so a change applies on the next reconnect even if the message is
 /// lost or arrives late.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) enum FirestoreListenerControl {
     Shutdown,
     TargetsChanged,
+    /// Listen to this target again from scratch, discarding its stored resume state.
+    ResyncTarget(FirestoreListenerTarget),
+}
+
+/// A cheap, cloneable handle for asking a running listener to resynchronise a target.
+///
+/// Separate from [`FirestoreListener`] so that code reacting to listen events - the cache above
+/// all - can ask for a resync without taking any lock the listener's own shutdown holds.
+#[derive(Clone, Debug)]
+pub struct FirestoreListenerControlHandle {
+    control_writer: Arc<UnboundedSender<FirestoreListenerControl>>,
+}
+
+impl FirestoreListenerControlHandle {
+    /// Discards the target's stored resume state and reopens the stream, so Firestore sends its
+    /// initial state again.
+    ///
+    /// Use this when the cached view of a target is known to have diverged from the server and
+    /// resuming would only carry the divergence forward. Does nothing if the listener has stopped.
+    pub fn resync_target(&self, target: FirestoreListenerTarget) {
+        self.control_writer
+            .send(FirestoreListenerControl::ResyncTarget(target))
+            .ok();
+    }
 }
 
 pub struct FirestoreListener<D, S>
@@ -383,6 +407,13 @@ where
             .keys()
             .cloned()
             .collect()
+    }
+
+    /// A handle for asking this listener to resynchronise a target while it runs.
+    pub fn control_handle(&self) -> FirestoreListenerControlHandle {
+        FirestoreListenerControlHandle {
+            control_writer: self.control_writer.clone(),
+        }
     }
 
     /// Whether this listener listens on the given target.
@@ -515,7 +546,9 @@ where
                     None | Some(FirestoreListenerControl::Shutdown) => {
                         shutdown_flag.store(true, Ordering::Relaxed);
                     }
-                    Some(FirestoreListenerControl::TargetsChanged) => {}
+                    // Nothing is being listened to, so there is nothing to resynchronise either.
+                    Some(FirestoreListenerControl::TargetsChanged)
+                    | Some(FirestoreListenerControl::ResyncTarget(_)) => {}
                 }
                 continue;
             }
@@ -549,6 +582,18 @@ where
                                 Some(FirestoreListenerControl::Shutdown) => {
                                     debug!("Exiting from listener on targets...");
                                     control_receiver.close();
+                                    break;
+                                }
+                                Some(FirestoreListenerControl::ResyncTarget(target)) => {
+                                    warn!(
+                                        ?target,
+                                        ?effective_delay,
+                                        "Resynchronising a listener target from scratch at the cache's request.",
+                                    );
+                                    Self::forget_resume_states(&storage, &targets_state, &[target]).await;
+                                    // Without this a target that keeps diverging would reconnect
+                                    // and re-download in a tight loop.
+                                    tokio::time::sleep(effective_delay).await;
                                     break;
                                 }
                                 Some(FirestoreListenerControl::TargetsChanged) => {

--- a/src/db/listen_changes.rs
+++ b/src/db/listen_changes.rs
@@ -597,13 +597,25 @@ where
                                     break;
                                 }
                                 Some(FirestoreListenerControl::TargetsChanged) => {
-                                    // Collapse a burst of changes into a single reconnect.
+                                    // Collapse a burst of changes into a single reconnect. A resync
+                                    // drained here still has to take effect, or the target would
+                                    // come back resuming from the position we were asked to drop.
+                                    let mut drained_resyncs = Vec::new();
                                     while let Ok(queued) = control_receiver.try_recv() {
-                                        if queued == FirestoreListenerControl::Shutdown {
-                                            shutdown_flag.store(true, Ordering::Relaxed);
-                                            control_receiver.close();
-                                            break;
+                                        match queued {
+                                            FirestoreListenerControl::Shutdown => {
+                                                shutdown_flag.store(true, Ordering::Relaxed);
+                                                control_receiver.close();
+                                                break;
+                                            }
+                                            FirestoreListenerControl::ResyncTarget(target) => {
+                                                drained_resyncs.push(target);
+                                            }
+                                            FirestoreListenerControl::TargetsChanged => {}
                                         }
+                                    }
+                                    if !drained_resyncs.is_empty() {
+                                        Self::forget_resume_states(&storage, &targets_state, &drained_resyncs).await;
                                     }
                                     debug!("Listener targets changed. Reopening the stream with the new set...");
                                     break;
@@ -625,23 +637,28 @@ where
 
                                         match event.response_type {
                                             Some(listen_response::ResponseType::TargetChange(target_change)) => {
-                                                if !target_change.resume_token.is_empty()
-                                                    && !Self::store_resume_token(&storage, &targets_state, &target_change).await
-                                                {
-                                                    break;
-                                                }
-
                                                 let change_type = target_change::TargetChangeType::try_from(
                                                     target_change.target_change_type,
                                                 ).ok();
                                                 let affected = Self::affected_targets(&targets_state, &target_change.target_ids);
                                                 let cause = target_change.cause.clone();
+                                                let resume_token = target_change.resume_token.clone();
+                                                let target_ids = target_change.target_ids.clone();
 
                                                 // Anything listening on this - the cache above all -
                                                 // has to see the change, and drop what it holds for a
                                                 // reset target, before the stream is reopened.
                                                 if let Err(err) = cb(listen_response::ResponseType::TargetChange(target_change)).await {
                                                     error!(%err, "Listener callback function error occurred.");
+                                                    break;
+                                                }
+
+                                                // Stored only once the change has been applied. A
+                                                // token saved before that would, after a failure
+                                                // here, resume past a change nothing acted on.
+                                                if !resume_token.is_empty()
+                                                    && !Self::store_resume_token(&storage, &targets_state, &resume_token, &target_ids).await
+                                                {
                                                     break;
                                                 }
 
@@ -684,7 +701,14 @@ where
                                             None  =>  {}
                                         }
                                     }
-                                    Ok(None) => break,
+                                    Ok(None) => {
+                                        // A clean close still needs the retry delay: without it a
+                                        // server that closes immediately would be reconnected to in
+                                        // a tight loop.
+                                        debug!(?effective_delay, "Listen stream closed. Reconnecting after the specified delay...");
+                                        tokio::time::sleep(effective_delay).await;
+                                        break;
+                                    }
                                     Err(err) => {
                                         Self::handle_listener_error(
                                             err,
@@ -791,13 +815,14 @@ where
     async fn store_resume_token(
         storage: &S,
         targets_state: &FirestoreListenerTargetsState,
-        target_change: &TargetChange,
+        resume_token: &[u8],
+        target_ids: &[i32],
     ) -> bool {
-        let Ok(affected) = Self::affected_targets(targets_state, &target_change.target_ids) else {
+        let Ok(affected) = Self::affected_targets(targets_state, target_ids) else {
             return false;
         };
 
-        let new_token: FirestoreListenerToken = target_change.resume_token.clone().into();
+        let new_token: FirestoreListenerToken = resume_token.to_vec().into();
 
         for target_id in affected {
             if let Err(err) = storage

--- a/src/db/listen_changes_state_storage.rs
+++ b/src/db/listen_changes_state_storage.rs
@@ -7,32 +7,44 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::*;
 
+/// Stores where each listener target should resume from, so a listener picks up where it left off
+/// rather than replaying everything.
+///
+/// A resume token belongs to one target's *query*: feeding it to a different query is rejected by
+/// Firestore, which is why removing a target forgets its state rather than leaving it behind.
+///
+/// Two implementations ship with this crate: [`FirestoreMemListenStateStorage`], which starts fresh
+/// on every process, and [`FirestoreTempFilesListenStateStorage`], which survives restarts.
 #[async_trait]
 pub trait FirestoreResumeStateStorage {
+    /// Returns where the target should resume from, or `None` to listen to it from scratch.
+    ///
+    /// Called once per target each time the listen stream is opened.
     async fn read_resume_state(
         &self,
         target: &FirestoreListenerTarget,
     ) -> AnyBoxedErrResult<Option<FirestoreListenerTargetResumeType>>;
 
+    /// Records the newest resume token Firestore issued for a target.
+    ///
+    /// Called as tokens arrive, and only after the change they cover has been handled, so a stored
+    /// token never points past work that was not applied.
     async fn update_resume_token(
         &self,
         target: &FirestoreListenerTarget,
         token: FirestoreListenerToken,
     ) -> AnyBoxedErrResult<()>;
 
-    /// Forgets any stored resume state for a target, so that the next listen starts fresh.
+    /// Discards any stored state for a target, so the next listen starts it from scratch.
     ///
-    /// This is called when Firestore reports that it removed or reset a target, in which case the
-    /// stored token is at best useless and at worst the cause, and when a target is removed from a
-    /// listener so that its ID can be reused safely.
+    /// Called when Firestore resets or removes a target - where the stored token is at best useless
+    /// and at worst the cause - and when a target is removed from a listener, so that its ID can be
+    /// given to a different query safely.
     ///
-    /// The default implementation does nothing, which keeps existing implementations compiling.
-    /// Implement it if your storage is durable: otherwise a stale token is read back on the next
-    /// process start, and a resume token belonging to a different query is rejected by Firestore.
-    async fn forget_resume_state(&self, target: &FirestoreListenerTarget) -> AnyBoxedErrResult<()> {
-        let _ = target;
-        Ok(())
-    }
+    /// Durable implementations must actually erase it. Leaving the state behind hands a stale token
+    /// back on the next process start, which Firestore rejects with `INVALID_ARGUMENT`.
+    /// Implementations that keep nothing across restarts may simply do nothing here.
+    async fn forget_resume_state(&self, target: &FirestoreListenerTarget) -> AnyBoxedErrResult<()>;
 }
 
 #[derive(Clone, Debug)]

--- a/src/db/listen_changes_state_storage.rs
+++ b/src/db/listen_changes_state_storage.rs
@@ -19,6 +19,20 @@ pub trait FirestoreResumeStateStorage {
         target: &FirestoreListenerTarget,
         token: FirestoreListenerToken,
     ) -> AnyBoxedErrResult<()>;
+
+    /// Forgets any stored resume state for a target, so that the next listen starts fresh.
+    ///
+    /// This is called when Firestore reports that it removed or reset a target, in which case the
+    /// stored token is at best useless and at worst the cause, and when a target is removed from a
+    /// listener so that its ID can be reused safely.
+    ///
+    /// The default implementation does nothing, which keeps existing implementations compiling.
+    /// Implement it if your storage is durable: otherwise a stale token is read back on the next
+    /// process start, and a resume token belonging to a different query is rejected by Firestore.
+    async fn forget_resume_state(&self, target: &FirestoreListenerTarget) -> AnyBoxedErrResult<()> {
+        let _ = target;
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -86,6 +100,20 @@ impl FirestoreResumeStateStorage for FirestoreTempFilesListenStateStorage {
             hex::encode(token.value()),
         )?)
     }
+
+    async fn forget_resume_state(
+        &self,
+        target: &FirestoreListenerTarget,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let target_state_file_name = self.get_file_path(target);
+
+        match std::fs::remove_file(&target_state_file_name) {
+            Ok(()) => Ok(()),
+            // Nothing stored for this target is the outcome we wanted anyway.
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(Box::new(err)),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -128,5 +156,97 @@ impl FirestoreResumeStateStorage for FirestoreMemListenStateStorage {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.tokens.write().await.insert(target.clone(), token);
         Ok(())
+    }
+
+    async fn forget_resume_state(
+        &self,
+        target: &FirestoreListenerTarget,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.tokens.write().await.remove(target);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(id: u32) -> FirestoreListenerTarget {
+        FirestoreListenerTarget::new(id)
+    }
+
+    fn token(bytes: &[u8]) -> FirestoreListenerToken {
+        FirestoreListenerToken::new(bytes.to_vec())
+    }
+
+    fn stored_token(resume_state: Option<FirestoreListenerTargetResumeType>) -> Option<Vec<u8>> {
+        match resume_state {
+            Some(FirestoreListenerTargetResumeType::Token(token)) => Some(token.into_value()),
+            _ => None,
+        }
+    }
+
+    #[tokio::test]
+    async fn mem_storage_forgets_only_the_named_target() {
+        let storage = FirestoreMemListenStateStorage::new();
+        storage
+            .update_resume_token(&target(1), token(b"one"))
+            .await
+            .unwrap();
+        storage
+            .update_resume_token(&target(2), token(b"two"))
+            .await
+            .unwrap();
+
+        storage.forget_resume_state(&target(1)).await.unwrap();
+
+        assert_eq!(
+            stored_token(storage.read_resume_state(&target(1)).await.unwrap()),
+            None
+        );
+        assert_eq!(
+            stored_token(storage.read_resume_state(&target(2)).await.unwrap()),
+            Some(b"two".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn mem_storage_forgetting_an_unknown_target_succeeds() {
+        let storage = FirestoreMemListenStateStorage::new();
+        storage.forget_resume_state(&target(42)).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn temp_files_storage_forgets_only_the_named_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = FirestoreTempFilesListenStateStorage::with_temp_dir(dir.path());
+
+        storage
+            .update_resume_token(&target(1), token(b"one"))
+            .await
+            .unwrap();
+        storage
+            .update_resume_token(&target(2), token(b"two"))
+            .await
+            .unwrap();
+
+        storage.forget_resume_state(&target(1)).await.unwrap();
+
+        assert_eq!(
+            stored_token(storage.read_resume_state(&target(1)).await.unwrap()),
+            None
+        );
+        assert_eq!(
+            stored_token(storage.read_resume_state(&target(2)).await.unwrap()),
+            Some(b"two".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn temp_files_storage_forgetting_an_unstored_target_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = FirestoreTempFilesListenStateStorage::with_temp_dir(dir.path());
+
+        storage.forget_resume_state(&target(42)).await.unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,30 @@ pub type FirestoreResult<T> = std::result::Result<T, FirestoreError>;
 /// underlying gRPC/protobuf structure for a Firestore document.
 pub type FirestoreDocument = gcloud_sdk::google::firestore::v1::Document;
 
+/// The kind of change a listener reports for one of its targets.
+///
+/// This refers to `gcloud_sdk::google::firestore::v1::target_change::TargetChangeType`, and is
+/// re-exported so that a
+/// [`FirestoreListenEvent::TargetChange`](crate::FirestoreListenEvent::TargetChange) can be
+/// matched without depending on `gcloud-sdk` directly:
+///
+/// ```rust,no_run
+/// # use firestore::*;
+/// # fn example(event: FirestoreListenEvent) {
+/// if let FirestoreListenEvent::TargetChange(target_change) = event {
+///     match FirestoreListenerTargetChangeType::try_from(target_change.target_change_type) {
+///         // The target now reflects a consistent snapshot.
+///         Ok(FirestoreListenerTargetChangeType::Current) => {}
+///         // Firestore dropped the target; `target_change.cause` says why.
+///         Ok(FirestoreListenerTargetChangeType::Remove) => {}
+///         _ => {}
+///     }
+/// }
+/// # }
+/// ```
+pub type FirestoreListenerTargetChangeType =
+    gcloud_sdk::google::firestore::v1::target_change::TargetChangeType;
+
 mod firestore_meta;
 
 /// Re-exports all public items from the `firestore_meta` module.

--- a/tests/caching_dynamic_collections_test.rs
+++ b/tests/caching_dynamic_collections_test.rs
@@ -1,0 +1,133 @@
+use crate::common::{eventually_async, populate_collection, setup};
+use futures::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+mod common;
+use firestore::errors::FirestoreError;
+use firestore::*;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+struct MyTestStructure {
+    some_id: String,
+    some_string: String,
+}
+
+const FIRST_COLLECTION: &str = "integration-test-caching-dynamic-first";
+const SECOND_COLLECTION: &str = "integration-test-caching-dynamic-second";
+
+/// Collections can be added to and removed from a live cache, so applications whose set of cached
+/// collections changes do not have to tear the cache down and preload everything again.
+#[tokio::test]
+async fn collections_can_be_added_and_removed_on_a_live_cache(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let db = setup().await?;
+
+    for collection in [FIRST_COLLECTION, SECOND_COLLECTION] {
+        populate_collection(
+            &db,
+            collection,
+            5,
+            |i| MyTestStructure {
+                some_id: format!("test-{i}"),
+                some_string: format!("Test value {i}"),
+            },
+            |ms| ms.some_id.clone(),
+        )
+        .await?;
+    }
+
+    let cache = FirestoreCache::memory(&db)
+        .name("dynamic-collections-cache")
+        .preloaded_collection(FIRST_COLLECTION)
+        .build()
+        .await?;
+
+    // Derived *before* the second collection is added. It shares the cache's backend rather than a
+    // copy, so it must see the addition without being recreated.
+    let cached_only_db = db.read_cached_only(&cache);
+
+    assert_eq!(cache.cached_collections().len(), 1);
+
+    // Not cached yet, so a cache-only listing has to refuse rather than answer emptily.
+    let before = list_cached(&cached_only_db, SECOND_COLLECTION).await;
+    assert!(
+        matches!(before, Err(FirestoreError::CacheError(_))),
+        "an uncached collection should not be listable, got {before:?}"
+    );
+
+    cache
+        .add_collection(FirestoreCacheCollection::new(SECOND_COLLECTION).preload_all())
+        .await?;
+
+    assert_eq!(cache.cached_collections().len(), 2);
+
+    let listed = list_cached(&cached_only_db, SECOND_COLLECTION).await?;
+    assert_eq!(listed.len(), 5);
+
+    // The listener covers the new collection too, so a write reaches the cache.
+    db.fluent()
+        .update()
+        .fields(paths!(MyTestStructure::some_string))
+        .in_col(SECOND_COLLECTION)
+        .document_id("test-2")
+        .object(&MyTestStructure {
+            some_id: "test-2".to_string(),
+            some_string: "updated".to_string(),
+        })
+        .execute::<()>()
+        .await?;
+
+    let propagated = eventually_async(10, Duration::from_millis(500), {
+        let cached_only_db = cached_only_db.clone();
+        move || {
+            let cached_only_db = cached_only_db.clone();
+            async move {
+                let found: Option<MyTestStructure> = cached_only_db
+                    .fluent()
+                    .select()
+                    .by_id_in(SECOND_COLLECTION)
+                    .obj()
+                    .one("test-2")
+                    .await?;
+                Ok(matches!(found, Some(doc) if doc.some_string == "updated"))
+            }
+        }
+    })
+    .await?;
+    assert!(
+        propagated,
+        "the listener did not pick up the collection added at runtime"
+    );
+
+    cache.remove_collection(SECOND_COLLECTION).await?;
+
+    assert_eq!(cache.cached_collections().len(), 1);
+    let after = list_cached(&cached_only_db, SECOND_COLLECTION).await;
+    assert!(
+        matches!(after, Err(FirestoreError::CacheError(_))),
+        "a removed collection should no longer be listable, got {after:?}"
+    );
+
+    // Removing one collection must not disturb the other.
+    assert_eq!(
+        list_cached(&cached_only_db, FIRST_COLLECTION).await?.len(),
+        5
+    );
+
+    assert!(!cache.remove_collection(SECOND_COLLECTION).await?);
+
+    cache.shutdown().await?;
+    Ok(())
+}
+
+async fn list_cached(db: &FirestoreDb, collection: &str) -> FirestoreResult<Vec<MyTestStructure>> {
+    db.fluent()
+        .list()
+        .from(collection)
+        .obj::<MyTestStructure>()
+        .stream_all_with_errors()
+        .await?
+        .try_collect()
+        .await
+}

--- a/tests/caching_resume_token_test.rs
+++ b/tests/caching_resume_token_test.rs
@@ -1,0 +1,157 @@
+use crate::common::{eventually_async, populate_collection, setup};
+use futures::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio::time::sleep;
+
+mod common;
+use firestore::*;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+struct MyTestStructure {
+    some_id: String,
+    some_string: String,
+}
+
+const TEST_COLLECTION_NAME: &str = "integration-test-caching-resume-token";
+const LISTENER_TARGET: u32 = 1500;
+const DELETED_DOC_ID: &str = "test-3";
+
+/// A persistent cache resumes from a stored token, so a token that is no longer valid is the way
+/// its listener goes silently stale: the stream stops delivering and the cache serves whatever it
+/// happened to hold, including documents deleted in the meantime.
+///
+/// This drives that path end to end - corrupt the stored token, delete a document while the cache
+/// is down, and require the rebuilt cache to converge anyway.
+#[tokio::test]
+async fn recovers_when_the_stored_resume_token_is_no_longer_valid(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let db = setup().await?;
+
+    let data_dir = tempfile::tempdir()?.keep();
+
+    // Start from a known state: the document we delete later has to exist first.
+    populate_collection(
+        &db,
+        TEST_COLLECTION_NAME,
+        10,
+        |i| MyTestStructure {
+            some_id: format!("test-{i}"),
+            some_string: format!("Test value {i}"),
+        },
+        |ms| ms.some_id.clone(),
+    )
+    .await?;
+    sleep(Duration::from_secs(1)).await;
+
+    // First lifetime: preload the collection and let the listener store a resume token.
+    let cache = build_cache(&db, &data_dir).await?;
+
+    let token_file = data_dir.join(format!("firestore-listen-token.{LISTENER_TARGET}.tmp"));
+    assert!(
+        eventually_async(10, Duration::from_millis(500), || {
+            let token_file = token_file.clone();
+            async move { Ok(token_file.exists()) }
+        })
+        .await?,
+        "the listener never stored a resume token, so there is nothing to invalidate"
+    );
+
+    // `shutdown` closes the database, so the second cache below can open the same directory
+    // without the first one having been dropped.
+    cache.shutdown().await?;
+
+    // Not a token Firestore ever issued.
+    std::fs::write(&token_file, "deadbeefdeadbeefdeadbeef")?;
+
+    // Delete while the cache is down. Only a resync can notice this: a target re-added from a
+    // point in time is told about documents that exist, never about ones that no longer do.
+    db.fluent()
+        .delete()
+        .from(TEST_COLLECTION_NAME)
+        .document_id(DELETED_DOC_ID)
+        .execute()
+        .await?;
+
+    // Second lifetime over the same directory. The collection is already populated, so the cache
+    // skips preloading and resumes from the token we just invalidated.
+    let cache = build_cache(&db, &data_dir).await?;
+
+    // Firestore reports the invalid token as a target removal carrying `INVALID_ARGUMENT: bad
+    // resume token`, so the cache drops the collection and stops serving listings from it.
+    let cached_db = db.read_through_cache(&cache);
+    let stopped_serving_the_deleted_doc = eventually_async(12, Duration::from_millis(500), {
+        let cached_db = cached_db.clone();
+        move || {
+            let cached_db = cached_db.clone();
+            async move {
+                let deleted: Option<MyTestStructure> = cached_db
+                    .fluent()
+                    .select()
+                    .by_id_in(TEST_COLLECTION_NAME)
+                    .obj()
+                    .one(DELETED_DOC_ID)
+                    .await?;
+                Ok(deleted.is_none())
+            }
+        }
+    })
+    .await?;
+
+    // ...and then the listener re-adds the target without the bad token, Firestore replays the
+    // collection, and the cache serves it on its own again - now without the deleted document.
+    // This is the half that proves the recovery finished rather than merely failing open.
+    let cached_only_db = db.read_cached_only(&cache);
+    let repopulated = eventually_async(8, Duration::from_secs(1), move || {
+        let cached_only_db = cached_only_db.clone();
+        async move {
+            // While the collection is being replayed the cache refuses the listing rather than
+            // answering it partially, so an error here means "not recovered yet", not a failure.
+            let listed: FirestoreResult<Vec<MyTestStructure>> = async {
+                cached_only_db
+                    .fluent()
+                    .list()
+                    .from(TEST_COLLECTION_NAME)
+                    .obj::<MyTestStructure>()
+                    .stream_all_with_errors()
+                    .await?
+                    .try_collect()
+                    .await
+            }
+            .await;
+
+            Ok(matches!(listed, Ok(docs) if docs.len() == 9
+                && !docs.iter().any(|d| d.some_id == DELETED_DOC_ID)))
+        }
+    })
+    .await?;
+
+    cache.shutdown().await?;
+    drop(cache);
+    std::fs::remove_dir_all(&data_dir).ok();
+
+    assert!(
+        stopped_serving_the_deleted_doc,
+        "the cache kept serving a document deleted while its resume token was invalid"
+    );
+    assert!(
+        repopulated,
+        "the cache never recovered: the target was not re-added and replayed after the bad token"
+    );
+
+    Ok(())
+}
+
+async fn build_cache(
+    db: &FirestoreDb,
+    data_dir: &std::path::Path,
+) -> Result<FirestorePersistentCache, Box<dyn std::error::Error + Send + Sync>> {
+    Ok(FirestorePersistentCache::builder(db)
+        .name("resume-token-cache")
+        .data_dir(data_dir)
+        .collection_with(TEST_COLLECTION_NAME, |c| {
+            c.preload_all_if_empty().listener_target(LISTENER_TARGET)
+        })
+        .build()
+        .await?)
+}

--- a/tests/caching_watched_documents_test.rs
+++ b/tests/caching_watched_documents_test.rs
@@ -1,0 +1,143 @@
+use crate::common::{eventually_async, populate_collection, setup};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+mod common;
+use firestore::errors::FirestoreError;
+use firestore::*;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+struct MyTestStructure {
+    some_id: String,
+    some_string: String,
+}
+
+const TEST_COLLECTION_NAME: &str = "integration-test-caching-watched-docs";
+const WATCHED: [&str; 2] = ["test-0", "test-1"];
+const UNWATCHED: &str = "test-4";
+
+/// A cache limited to named documents subscribes to exactly those documents, rather than to the
+/// whole collection. This is the shape to use for configuration and reference data, where the set
+/// of interesting documents is known up front.
+#[tokio::test]
+async fn a_cache_limited_to_named_documents_ignores_the_rest_of_the_collection(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let db = setup().await?;
+
+    populate_collection(
+        &db,
+        TEST_COLLECTION_NAME,
+        5,
+        |i| MyTestStructure {
+            some_id: format!("test-{i}"),
+            some_string: format!("Test value {i}"),
+        },
+        |ms| ms.some_id.clone(),
+    )
+    .await?;
+
+    let cache = FirestoreCache::memory(&db)
+        .name("watched-documents-cache")
+        .collection_with(TEST_COLLECTION_NAME, |c| c.documents(WATCHED).preload_all())
+        .build()
+        .await?;
+
+    let cached_db = db.read_cached_only(&cache);
+
+    // Only the watched documents were downloaded.
+    for document_id in WATCHED {
+        let found: Option<MyTestStructure> = cached_db
+            .fluent()
+            .select()
+            .by_id_in(TEST_COLLECTION_NAME)
+            .obj()
+            .one(document_id)
+            .await?;
+        assert!(found.is_some(), "{document_id} should have been preloaded");
+    }
+
+    let unwatched: Option<MyTestStructure> = db
+        .read_through_cache(&cache)
+        .fluent()
+        .select()
+        .by_id_in(TEST_COLLECTION_NAME)
+        .obj()
+        .one(UNWATCHED)
+        .await?;
+    assert!(
+        unwatched.is_some(),
+        "read-through should still fetch an unwatched document from Firestore"
+    );
+
+    // Holding a chosen subset, it must refuse to list the collection rather than answer partially.
+    let listing = cached_db
+        .fluent()
+        .list()
+        .from(TEST_COLLECTION_NAME)
+        .obj::<MyTestStructure>()
+        .stream_all_with_errors()
+        .await
+        .map(|_| ());
+    assert!(
+        matches!(listing, Err(FirestoreError::CacheError(_))),
+        "a documents watch must not be listable, got {listing:?}"
+    );
+
+    // A change to a watched document reaches the cache...
+    update(&db, WATCHED[0], "updated").await?;
+    assert!(
+        eventually_async(10, Duration::from_millis(500), {
+            let cached_db = cached_db.clone();
+            move || {
+                let cached_db = cached_db.clone();
+                async move {
+                    Ok(cached_string(&cached_db, WATCHED[0]).await? == Some("updated".to_string()))
+                }
+            }
+        })
+        .await?,
+        "a watched document should be kept up to date"
+    );
+
+    // ...while a change to an unwatched one never does, because the target does not cover it.
+    update(&db, UNWATCHED, "should-not-be-cached").await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert_eq!(
+        cached_string(&cached_db, UNWATCHED).await?,
+        None,
+        "an unwatched document must never enter the cache"
+    );
+
+    cache.shutdown().await?;
+    Ok(())
+}
+
+async fn cached_string(db: &FirestoreDb, document_id: &str) -> FirestoreResult<Option<String>> {
+    let found: Option<MyTestStructure> = db
+        .fluent()
+        .select()
+        .by_id_in(TEST_COLLECTION_NAME)
+        .obj()
+        .one(document_id)
+        .await?;
+    Ok(found.map(|doc| doc.some_string))
+}
+
+async fn update(
+    db: &FirestoreDb,
+    document_id: &str,
+    value: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    db.fluent()
+        .update()
+        .fields(paths!(MyTestStructure::some_string))
+        .in_col(TEST_COLLECTION_NAME)
+        .document_id(document_id)
+        .object(&MyTestStructure {
+            some_id: document_id.to_string(),
+            some_string: value.to_string(),
+        })
+        .execute::<()>()
+        .await?;
+    Ok(())
+}

--- a/tests/caching_watched_documents_test.rs
+++ b/tests/caching_watched_documents_test.rs
@@ -109,7 +109,65 @@ async fn a_cache_limited_to_named_documents_ignores_the_rest_of_the_collection(
     );
 
     cache.shutdown().await?;
+
+    // Each backend builds its listener targets on its own path, so assert the shape of the target
+    // itself. Checking cached contents instead would prove nothing here: writes are filtered to
+    // the watched set anyway, so a target covering the whole collection would look identical from
+    // the cache while quietly streaming every unrelated change in it.
+    for (name, targets) in [
+        ("memory", memory_backend_targets(&db).await?),
+        ("persistent", persistent_backend_targets(&db).await?),
+    ] {
+        assert_eq!(targets.len(), 1, "{name}: expected one target");
+        match &targets[0].target_type {
+            FirestoreTargetType::Documents(documents) => {
+                assert_eq!(documents.collection, TEST_COLLECTION_NAME, "{name}");
+                assert_eq!(documents.documents, WATCHED.to_vec(), "{name}");
+            }
+            other => panic!(
+                "{name}: a watched-documents collection must listen on a documents target, got \
+                 {other:?}"
+            ),
+        }
+    }
+
     Ok(())
+}
+
+fn watched_configuration(db: &FirestoreDb) -> FirestoreCacheConfiguration {
+    FirestoreCacheConfiguration::new().add_collection_config(
+        db,
+        FirestoreCacheCollectionConfiguration::new(
+            TEST_COLLECTION_NAME,
+            FirestoreListenerTarget::new(1600),
+            FirestoreCacheCollectionLoadMode::PreloadAllDocs,
+        )
+        .with_documents(WATCHED),
+    )
+}
+
+async fn memory_backend_targets(
+    db: &FirestoreDb,
+) -> Result<Vec<FirestoreListenerTargetParams>, Box<dyn std::error::Error + Send + Sync>> {
+    let backend = FirestoreMemoryCacheBackend::new(watched_configuration(db))?;
+    Ok(backend
+        .load(&FirestoreCacheOptions::new("watched-memory".into()), db)
+        .await?)
+}
+
+async fn persistent_backend_targets(
+    db: &FirestoreDb,
+) -> Result<Vec<FirestoreListenerTargetParams>, Box<dyn std::error::Error + Send + Sync>> {
+    let data_dir = tempfile::tempdir()?;
+    let backend = FirestorePersistentCacheBackend::with_options(
+        watched_configuration(db),
+        data_dir.path().join("redb"),
+    )?;
+    let targets = backend
+        .load(&FirestoreCacheOptions::new("watched-persistent".into()), db)
+        .await?;
+    backend.shutdown().await?;
+    Ok(targets)
 }
 
 async fn cached_string(db: &FirestoreDb, document_id: &str) -> FirestoreResult<Option<String>> {


### PR DESCRIPTION
The cache ignored DocumentRemove and every TargetChange, so a deleted document could stay cached indefinitely and a target Firestore dropped left the cache silently frozen; it now evicts on removal, resynchronises a reset or removed target, and refuses listings from a collection while it is being replayed.

Building on that, collections can be added and removed on a running cache, a collection can be limited to named documents so the listener watches just those instead of the whole collection, and the cache acts on Firestore's existence filter to notice changes it missed while disconnected. Shutdown now releases the backend's resources rather than holding them until drop.

Verified against a real Firestore project: 72 unit tests, 14 integration tests and 29 doc tests pass, and MIGRATION.md covers the behaviour changes.