### PR TITLE
fix(deps): update rust crate gcloud-sdk to 0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tls-webpki-roots = ["gcloud-sdk/tls-webpki-roots"]
 
 [dependencies]
 tracing = "0.1"
-gcloud-sdk = { version = "0.31.0", default-features = false, features = ["google-firestore-v1"] }
+gcloud-sdk = { version = "0.32", default-features = false, features = ["google-firestore-v1"] }
 hyper = { version = "1" }
 struct-path = "0.2"
 rvstruct = "0.3.2"


### PR DESCRIPTION
Bump gcloud-sdk to 0.32. Verified locally with fmt, clippy, doc build, lib tests, and the full integration test suite against the latestbit GCP project; no code changes were needed beyond the version bump.